### PR TITLE
Various build validation script tweaks

### DIFF
--- a/scripts/gradle/01-validate-incremental-building.sh
+++ b/scripts/gradle/01-validate-incremental-building.sh
@@ -104,7 +104,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 execute_first_build() {

--- a/scripts/gradle/01-validate-incremental-building.sh
+++ b/scripts/gradle/01-validate-incremental-building.sh
@@ -70,7 +70,7 @@ wizard_execute() {
   print_introduction
 
   print_bl
-  explain_prerequisites_ccud_gradle_plugin
+  explain_prerequisites_ccud_gradle_plugin ""
 
   print_bl
   explain_collect_git_details
@@ -174,35 +174,6 @@ and run the experiment again. This creates a cycle of run → measure → improv
 run.
 
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_ccud_gradle_plugin() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation - Configure build with Common Custom User Data Gradle plugin${RESTORE}
-
-To get the most out of this experiment and also when building with Gradle
-Enterprise during daily development, it is advisable that you apply the Common
-Custom User Data Gradle plugin to your build, if not already the case. Gradle
-provides the Common Custom User Data Gradle plugin as a free, open-source add-on.
-
-https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin
-
-An extract of a typical build configuration is described below.
-
-settings.gradle:
-plugins {
-    id 'com.gradle.enterprise' version '<latest version>'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '<latest version>'
-}
-
-Your updated build configuration should be pushed before proceeding.
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Gradle plugin and pushed the changes.${RESTORE}
 EOF
   print_wizard_text "${text}"
   wait_for_enter

--- a/scripts/gradle/01-validate-incremental-building.sh
+++ b/scripts/gradle/01-validate-incremental-building.sh
@@ -270,16 +270,13 @@ most relevant views in build scans to investigate what tasks were uptodate and
 what tasks executed in the second build, which of those tasks had the biggest
 impact on build performance, and what caused those tasks to not be uptodate.
 
-The 'Command Line Invocation' section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -295,16 +295,13 @@ local build caching and what tasks executed in the second build, which of those
 tasks had the biggest impact on build performance, and what caused those tasks
 to not be taken from the local build cache.
 
-The ‘Command Line Invocation’ section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -71,7 +71,7 @@ wizard_execute() {
   print_introduction
 
   print_bl
-  explain_prerequisites_ccud_gradle_plugin
+  explain_prerequisites_ccud_gradle_plugin ""
 
   print_bl
   explain_collect_git_details
@@ -198,35 +198,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_ccud_gradle_plugin() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation - Configure build with Common Custom User Data Gradle plugin${RESTORE}
-
-To get the most out of this experiment and also when building with Gradle
-Enterprise during daily development, it is advisable that you apply the Common
-Custom User Data Gradle plugin to your build, if not already the case. Gradle
-provides the Common Custom User Data Gradle plugin as a free, open-source add-on.
-
-https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin
-
-An extract of a typical build configuration is described below.
-
-settings.gradle:
-plugins {
-    id 'com.gradle.enterprise' version '<latest version>'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '<latest version>'
-}
-
-Your updated build configuration should be pushed before proceeding.
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Gradle plugin and pushed the changes.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -106,7 +106,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 execute_first_build() {

--- a/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -333,16 +333,13 @@ local build caching and what tasks executed in the second build, which of those
 tasks had the biggest impact on build performance, and what caused those tasks
 to not be taken from the local build cache.
 
-The ‘Command Line Invocation’ section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -72,7 +72,7 @@ wizard_execute() {
   print_introduction
 
   print_bl
-  explain_prerequisites_ccud_gradle_plugin
+  explain_prerequisites_ccud_gradle_plugin ""
 
   print_bl
   explain_collect_git_details
@@ -205,35 +205,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_ccud_gradle_plugin() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation - Configure build with Common Custom User Data Gradle plugin${RESTORE}
-
-To get the most out of this experiment and also when building with Gradle
-Enterprise during daily development, it is advisable that you apply the Common
-Custom User Data Gradle plugin to your build, if not already the case. Gradle
-provides the Common Custom User Data Gradle plugin as a free, open-source add-on.
-
-https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin
-
-An extract of a typical build configuration is described below.
-
-settings.gradle:
-plugins {
-    id 'com.gradle.enterprise' version '<latest version>'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '<latest version>'
-}
-
-Your updated build configuration should be pushed before proceeding.
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Gradle plugin and pushed the changes.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -110,7 +110,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 execute_first_build() {

--- a/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -100,7 +100,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 validate_required_args() {

--- a/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -68,13 +68,13 @@ wizard_execute() {
   explain_prerequisites_ccud_gradle_plugin "I."
 
   print_bl
-  explain_prerequisites_remote_build_cache_config
+  explain_prerequisites_remote_build_cache_config "II."
 
   print_bl
-  explain_prerequisites_empty_remote_build_cache
+  explain_prerequisites_empty_remote_build_cache "III."
 
   print_bl
-  explain_prerequisites_api_access
+  explain_prerequisites_api_access "IV."
 
   print_bl
   explain_first_build
@@ -210,109 +210,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_remote_build_cache_config() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation II. - Configure build for remote build caching${RESTORE}
-
-You must first configure your build for remote build caching. An extract of a
-typical build configuration is described below.
-
-gradle.properties:
-org.gradle.caching=true
-
-settings.gradle:
-def isCi = System.getenv('BUILD_URL') != null   // adjust to an env var that is always present in your CI environment
-buildCache {
-  local { enabled = false }                     // must be false for this experiment
-  remote(HttpBuildCache) {
-    url = 'https://ge.example.com/cache/exp4/'  // adjust to your GE hostname, and note the trailing slash
-    allowUntrustedServer = true                 // set to false if a trusted certificate is configured for the GE server
-    credentials { creds ->
-      // inject credentials with read-write access to the remote build cache via env vars set in your CI environment
-      creds.username = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
-      creds.password = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
-    }
-    enabled = true                              // must be true for this experiment
-    push = isCI                                 // must be true when the build runs in CI
-}}
-
-Your updated build configuration needs to be pushed to a separate branch that
-is only used for running the experiments.
-
-${USER_ACTION_COLOR}Press <Enter> once you have configured your build for remote build caching and pushed the changes.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_empty_remote_build_cache() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation III. - Purge remote build cache${RESTORE}
-
-It is important to use an empty remote build cache and to avoid that other
-builds write to the same remote build cache while this experiment is running.
-Ensuring that these preconditions are met will maximize the reproducibility
-and reliability of the experiment. Two different ways to meet these conditions
-are described below.
-
-a) If none of your builds are yet writing to the remote build cache besides
-the builds of this experiment, purge the remote build cache that your build
-is configured to connect to. You can purge the remote build cache by navigating
-in the browser to the 'Build Cache' admin section from the user menu of your
-Gradle Enterprise UI, selecting the build cache node the build is pointing to,
-and then clicking the 'Purge cache' button.
-
-b) If you are not in a position to purge the remote build cache, you can connect
-to a unique shard of the remote build cache each time you run this experiment.
-A shard is accessed via an identifier that is appended to the path of the remote
-build cache URL, for example https://ge.example.com/cache/exp4-2021-Dec31-take1/
-which encodes the experiment type, the current date, and a counter that needs
-to be increased every time the experiment is rerun. Using such an encoding
-schema ensures that for each run of the experiment an empty remote build cache
-will be used. You need to push the changes to the path of the remote build cache
-URL every time before you run the experiment.
-
-If you choose option b) and do not want to interfere with an already existing
-build caching configuration in your build and you are using the Common Custom
-User Data Gradle plugin, you can override the local and remote build cache
-configuration via system properties or environment variables right when
-triggering the build on CI. Details on how to provide the overrides are
-available from the documentation of the plugin.
-
-https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-gradle-plugin/README.md#configuration-overrides
-
-${USER_ACTION_COLOR}Press <Enter> once you have prepared the experiment to run with an empty remote build cache.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_api_access() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation IV. - Ensure Gradle Enterprise API access${RESTORE}
-
-Some build scan data will be fetched from the invoked builds via the Gradle
-Enterprise API. It is not strictly necessary that you have permission to
-call the Gradle Enterprise API while doing this experiment, but the summary
-provided at the end of the experiment will be more comprehensive if the build
-scan data is accessible. Details on how to check your access permissions and
-how to provide the necessary API credentials when running the experiment are
-available from the documentation of the build validation scripts.
-
-https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-gradle-enterprise
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) adjusted your access permissions and configured the API credentials on your machine.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -68,10 +68,10 @@ wizard_execute() {
   explain_prerequisites_ccud_gradle_plugin "I."
 
   print_bl
-  explain_prerequisites_remote_build_cache_config "II."
+  explain_prerequisites_gradle_remote_build_cache_config "II."
 
   print_bl
-  explain_prerequisites_empty_remote_build_cache "III."
+  explain_prerequisites_gradle_empty_remote_build_cache "III."
 
   print_bl
   explain_prerequisites_api_access "IV."

--- a/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -65,7 +65,7 @@ wizard_execute() {
   print_introduction
 
   print_bl
-  explain_prerequisites_ccud_gradle_plugin
+  explain_prerequisites_ccud_gradle_plugin "I."
 
   print_bl
   explain_prerequisites_remote_build_cache_config
@@ -210,35 +210,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_ccud_gradle_plugin() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation I. - Configure build with Common Custom User Data Gradle plugin${RESTORE}
-
-To get the most out of this experiment and also when building with Gradle
-Enterprise during daily development, it is advisable that you apply the Common
-Custom User Data Gradle plugin to your build, if not already the case. Gradle
-provides the Common Custom User Data Gradle plugin as a free, open-source add-on.
-
-https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin
-
-An extract of a typical build configuration is described below.
-
-settings.gradle:
-plugins {
-    id 'com.gradle.enterprise' version '<latest version>'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '<latest version>'
-}
-
-Your updated build configuration should be pushed before proceeding.
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Gradle plugin and pushed the changes.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -465,16 +465,13 @@ remote build caching and what tasks executed in the second build, which of those
 tasks had the biggest impact on build performance, and what caused those tasks
 to not be taken from the remote build cache.
 
-The 'Command Line Invocation' section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -625,16 +625,13 @@ from the remote cache and what tasks executed in the second build with cache
 misses, which of those tasks had the biggest impact on build performance, and
 what caused the cache misses.
 
-The ‘Command Line Invocation’ section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -76,13 +76,13 @@ wizard_execute() {
   explain_prerequisites_ccud_gradle_plugin "I."
 
   print_bl
-  explain_prerequisites_remote_build_cache_config
+  explain_prerequisites_remote_build_cache_config "II."
 
   print_bl
-  explain_prerequisites_empty_remote_build_cache
+  explain_prerequisites_empty_remote_build_cache "III."
 
   print_bl
-  explain_prerequisites_api_access
+  explain_prerequisites_api_access "IV."
 
   print_bl
   explain_ci_build
@@ -270,109 +270,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_remote_build_cache_config() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation II. - Configure build for remote build caching${RESTORE}
-
-You must first configure your build for remote build caching. An extract of a
-typical build configuration is described below.
-
-gradle.properties:
-org.gradle.caching=true
-
-settings.gradle:
-def isCi = System.getenv('BUILD_URL') != null   // adjust to an env var that is always present in your CI environment
-buildCache {
-  local { enabled = false }                     // must be false for this experiment
-  remote(HttpBuildCache) {
-    url = 'https://ge.example.com/cache/exp5/'  // adjust to your GE hostname, and note the trailing slash
-    allowUntrustedServer = true                 // set to false if a trusted certificate is configured for the GE server
-    credentials { creds ->
-      // inject credentials with read-write access to the remote build cache via env vars set in your CI environment
-      creds.username = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
-      creds.password = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
-    }
-    enabled = true                              // must be true for this experiment
-    push = isCI                                 // must be true when the build runs in CI
-}}
-
-Your updated build configuration needs to be pushed to a separate branch that
-is only used for running the experiments.
-
-${USER_ACTION_COLOR}Press <Enter> once you have configured your build for remote build caching and pushed the changes.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_empty_remote_build_cache() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation III. - Purge remote build cache${RESTORE}
-
-It is important to use an empty remote build cache and to avoid that other
-builds write to the same remote build cache while this experiment is running.
-Ensuring that these preconditions are met will maximize the reproducibility
-and reliability of the experiment. Two different ways to meet these conditions
-are described below.
-
-a) If none of your builds are yet writing to the remote build cache besides
-the builds of this experiment, purge the remote build cache that your build
-is configured to connect to. You can purge the remote build cache by navigating
-in the browser to the 'Build Cache' admin section from the user menu of your
-Gradle Enterprise UI, selecting the build cache node the build is pointing to,
-and then clicking the 'Purge cache' button.
-
-b) If you are not in a position to purge the remote build cache, you can connect
-to a unique shard of the remote build cache each time you run this experiment.
-A shard is accessed via an identifier that is appended to the path of the remote
-build cache URL, for example https://ge.example.com/cache/exp5-2021-Dec31-take1/
-which encodes the experiment type, the current date, and a counter that needs
-to be increased every time the experiment is rerun. Using such an encoding
-schema ensures that for each run of the experiment an empty remote build cache
-will be used. You need to push the changes to the path of the remote build cache
-URL every time before you run the experiment.
-
-If you choose option b) and do not want to interfere with an already existing
-build caching configuration in your build and you are using the Common Custom
-User Data Gradle plugin, you can override the local and remote build cache
-configuration via system properties or environment variables right when
-triggering the build on CI. Details on how to provide the overrides are
-available from the documentation of the plugin.
-
-https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-gradle-plugin/README.md#configuration-overrides
-
-${USER_ACTION_COLOR}Press <Enter> once you have prepared the experiment to run with an empty remote build cache.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_api_access() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation IV. - Ensure Gradle Enterprise API access${RESTORE}
-
-Some build scan data will be fetched from the invoked builds via the Gradle
-Enterprise API. It is not strictly necessary that you have permission to
-call the Gradle Enterprise API while doing this experiment, but the summary
-provided at the end of the experiment will be more comprehensive if the build
-scan data is accessible. Details on how to check your access permissions and
-how to provide the necessary API credentials when running the experiment are
-available from the documentation of the build validation scripts.
-
-https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-gradle-enterprise
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) adjusted your access permissions and configured the API credentials on your machine.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -127,7 +127,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 process_script_arguments() {

--- a/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -76,10 +76,10 @@ wizard_execute() {
   explain_prerequisites_ccud_gradle_plugin "I."
 
   print_bl
-  explain_prerequisites_remote_build_cache_config "II."
+  explain_prerequisites_gradle_remote_build_cache_config "II."
 
   print_bl
-  explain_prerequisites_empty_remote_build_cache "III."
+  explain_prerequisites_gradle_empty_remote_build_cache "III."
 
   print_bl
   explain_prerequisites_api_access "IV."

--- a/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -73,7 +73,7 @@ wizard_execute() {
   print_introduction
 
   print_bl
-  explain_prerequisites_ccud_gradle_plugin
+  explain_prerequisites_ccud_gradle_plugin "I."
 
   print_bl
   explain_prerequisites_remote_build_cache_config
@@ -270,35 +270,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_ccud_gradle_plugin() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation I. - Configure build with Common Custom User Data Gradle plugin${RESTORE}
-
-To get the most out of this experiment and also when building with Gradle
-Enterprise during daily development, it is advisable that you apply the Common
-Custom User Data Gradle plugin to your build, if not already the case. Gradle
-provides the Common Custom User Data Gradle plugin as a free, open-source add-on.
-
-https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin
-
-An extract of a typical build configuration is described below.
-
-settings.gradle:
-plugins {
-    id 'com.gradle.enterprise' version '<latest version>'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '<latest version>'
-}
-
-Your updated build configuration should be pushed before proceeding.
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Gradle plugin and pushed the changes.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -140,14 +140,20 @@ collect_git_commit_id() {
 }
 
 collect_gradle_details() {
-  collect_gradle_root_project_directory
+  collect_root_project_directory
   collect_gradle_tasks
   collect_gradle_extra_args
 }
 
-collect_gradle_root_project_directory() {
+collect_maven_details() {
+  collect_root_project_directory
+  collect_maven_goals
+  collect_maven_extra_args
+}
+
+collect_root_project_directory() {
   local default_project_dir="<the repository's root directory>"
-  prompt_for_setting "Which directory contains the Gradle root project?" "${project_dir}" "${default_project_dir}" project_dir
+  prompt_for_setting "Which directory contains the ${BUILD_TOOL} root project?" "${project_dir}" "${default_project_dir}" project_dir
   if [[ "${project_dir}" == "${default_project_dir}" ]]; then
     project_dir=''
   fi
@@ -157,21 +163,16 @@ collect_gradle_tasks() {
   prompt_for_setting "What are the Gradle tasks to invoke?" "${tasks}" "assemble" tasks
 }
 
+collect_maven_goals() {
+  prompt_for_setting "What are the Maven goals to invoke?" "${tasks}" "package" tasks
+}
+
 collect_gradle_extra_args() {
   local default_extra_args="<none>"
   prompt_for_setting "What are additional cmd line arguments to pass to the Gradle invocation?" "${extra_args}" "${default_extra_args}" extra_args
   if [[ "${extra_args}" == "${default_extra_args}" ]]; then
     extra_args=''
   fi
-}
-
-collect_maven_details() {
-  collect_maven_goals
-  collect_maven_extra_args
-}
-
-collect_maven_goals() {
-  prompt_for_setting "What are the Maven goals to invoke?" "${tasks}" "package" tasks
 }
 
 collect_maven_extra_args() {

--- a/scripts/lib/info.sh
+++ b/scripts/lib/info.sh
@@ -138,9 +138,9 @@ print_experiment_specific_info() {
 print_build_scans() {
   for (( i=0; i<2; i++ )); do
     if [ -z "${build_outcomes[i]}" ]; then
-      summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]} BUILD SCAN DATA FETCH FAILED${RESTORE}"
+      summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]}BUILD SCAN DATA FETCH FAILED${RESTORE}"
     elif [[ "${build_outcomes[i]}" == "FAILED" ]]; then
-      summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]} FAILED${RESTORE}"
+      summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]}FAILED${RESTORE}"
     else
       summary_row "Build scan ${ORDINALS[i]} build:" "${build_scan_urls[i]}"
     fi

--- a/scripts/lib/wizard.sh
+++ b/scripts/lib/wizard.sh
@@ -110,3 +110,22 @@ EOF
   print_wizard_text "${text}"
   wait_for_enter
 }
+
+explain_command_to_repeat_experiment() {
+  local text
+  IFS='' read -r -d '' text <<EOF
+The 'Command Line Invocation' section below demonstrates how you can rerun the
+experiment with the same configuration and in non-interactive mode.
+EOF
+  echo -n "${text}"
+}
+
+explain_when_to_rerun_experiment() {
+  local text
+  IFS='' read -r -d '' text <<EOF
+Once you have addressed the issues surfaced in build scans and pushed the
+changes to your Git repository, you can rerun the experiment and start over
+the cycle of run → measure → improve → run.
+EOF
+  echo -n "${text}"
+}

--- a/scripts/lib/wizard.sh
+++ b/scripts/lib/wizard.sh
@@ -36,6 +36,42 @@ Experiment ${EXP_NO}: ${EXP_DESCRIPTION}${RESTORE}
 EOF
 }
 
+explain_prerequisites_ccud_gradle_plugin() {
+  local text preparation_step
+
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
+
+  IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Preparation ${preparation_step}- Configure build with Common Custom User Data Gradle plugin${RESTORE}
+
+To get the most out of this experiment and also when building with Gradle
+Enterprise during daily development, it is advisable that you apply the Common
+Custom User Data Gradle plugin to your build, if not already the case. Gradle
+provides the Common Custom User Data Gradle plugin as a free, open-source add-on.
+
+https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin
+
+An extract of a typical build configuration is described below.
+
+settings.gradle:
+plugins {
+    id 'com.gradle.enterprise' version '<latest version>'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '<latest version>'
+}
+
+Your updated build configuration should be pushed before proceeding.
+
+${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Gradle plugin and pushed the changes.${RESTORE}
+EOF
+  print_wizard_text "${text}"
+  wait_for_enter
+}
+
 explain_experiment_dir() {
   wizard "All of the work we do for this experiment will be stored in
 $(info "${EXP_DIR}")"

--- a/scripts/lib/wizard.sh
+++ b/scripts/lib/wizard.sh
@@ -72,6 +72,130 @@ EOF
   wait_for_enter
 }
 
+explain_prerequisites_remote_build_cache_config() {
+  local text preparation_step
+
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
+
+  IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Preparation ${preparation_step}- Configure build for remote build caching${RESTORE}
+
+You must first configure your build for remote build caching. An extract of a
+typical build configuration is described below.
+
+gradle.properties:
+org.gradle.caching=true
+
+settings.gradle:
+def isCi = System.getenv('BUILD_URL') != null   // adjust to an env var that is always present in your CI environment
+buildCache {
+  local { enabled = false }                     // must be false for this experiment
+  remote(HttpBuildCache) {
+    url = 'https://ge.example.com/cache/exp4/'  // adjust to your GE hostname, and note the trailing slash
+    allowUntrustedServer = true                 // set to false if a trusted certificate is configured for the GE server
+    credentials { creds ->
+      // inject credentials with read-write access to the remote build cache via env vars set in your CI environment
+      creds.username = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
+      creds.password = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
+    }
+    enabled = true                              // must be true for this experiment
+    push = isCI                                 // must be true when the build runs in CI
+}}
+
+Your updated build configuration needs to be pushed to a separate branch that
+is only used for running the experiments.
+
+${USER_ACTION_COLOR}Press <Enter> once you have configured your build for remote build caching and pushed the changes.${RESTORE}
+EOF
+  print_wizard_text "${text}"
+  wait_for_enter
+}
+
+explain_prerequisites_empty_remote_build_cache() {
+  local text preparation_step
+
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
+
+  IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Preparation ${preparation_step}- Purge remote build cache${RESTORE}
+
+It is important to use an empty remote build cache and to avoid that other
+builds write to the same remote build cache while this experiment is running.
+Ensuring that these preconditions are met will maximize the reproducibility
+and reliability of the experiment. Two different ways to meet these conditions
+are described below.
+
+a) If none of your builds are yet writing to the remote build cache besides
+the builds of this experiment, purge the remote build cache that your build
+is configured to connect to. You can purge the remote build cache by navigating
+in the browser to the 'Build Cache' admin section from the user menu of your
+Gradle Enterprise UI, selecting the build cache node the build is pointing to,
+and then clicking the 'Purge cache' button.
+
+b) If you are not in a position to purge the remote build cache, you can connect
+to a unique shard of the remote build cache each time you run this experiment.
+A shard is accessed via an identifier that is appended to the path of the remote
+build cache URL, for example https://ge.example.com/cache/exp4-2021-Dec31-take1/
+which encodes the experiment type, the current date, and a counter that needs
+to be increased every time the experiment is rerun. Using such an encoding
+schema ensures that for each run of the experiment an empty remote build cache
+will be used. You need to push the changes to the path of the remote build cache
+URL every time before you run the experiment.
+
+If you choose option b) and do not want to interfere with an already existing
+build caching configuration in your build and you are using the Common Custom
+User Data Gradle plugin, you can override the local and remote build cache
+configuration via system properties or environment variables right when
+triggering the build on CI. Details on how to provide the overrides are
+available from the documentation of the plugin.
+
+https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-gradle-plugin/README.md#configuration-overrides
+
+${USER_ACTION_COLOR}Press <Enter> once you have prepared the experiment to run with an empty remote build cache.${RESTORE}
+EOF
+  print_wizard_text "${text}"
+  wait_for_enter
+}
+
+explain_prerequisites_api_access() {
+  local text preparation_step
+
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
+
+  IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Preparation ${preparation_step}- Ensure Gradle Enterprise API access${RESTORE}
+
+Some build scan data will be fetched from the invoked builds via the Gradle
+Enterprise API. It is not strictly necessary that you have permission to
+call the Gradle Enterprise API while doing this experiment, but the summary
+provided at the end of the experiment will be more comprehensive if the build
+scan data is accessible. Details on how to check your access permissions and
+how to provide the necessary API credentials when running the experiment are
+available from the documentation of the build validation scripts.
+
+https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-gradle-enterprise
+
+${USER_ACTION_COLOR}Press <Enter> once you have (optionally) adjusted your access permissions and configured the API credentials on your machine.${RESTORE}
+EOF
+  print_wizard_text "${text}"
+  wait_for_enter
+}
+
 explain_experiment_dir() {
   wizard "All of the work we do for this experiment will be stored in
 $(info "${EXP_DIR}")"

--- a/scripts/lib/wizard.sh
+++ b/scripts/lib/wizard.sh
@@ -72,7 +72,52 @@ EOF
   wait_for_enter
 }
 
-explain_prerequisites_remote_build_cache_config() {
+explain_prerequisites_ccud_maven_plugin() {
+  local text preparation_step
+
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
+
+  IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Preparation ${preparation_step}- Configure build with Common Custom User Data Maven extension${RESTORE}
+
+To get the most out of this experiment and also when building with Gradle
+Enterprise during daily development, it is advisable that you apply the Common
+Custom User Data Maven extension to your build, if not already the case. Gradle
+provides the Common Custom User Data Maven extension as a free, open-source add-on.
+
+https://github.com/gradle/gradle-enterprise-build-config-samples/tree/master/common-custom-user-data-maven-extension
+
+An extract of a typical build configuration is described below.
+
+.mvn/extensions.xml:
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>gradle-enterprise-maven-extension</artifactId>
+        <version>{latest version}</version>
+    </extension>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>common-custom-user-data-maven-extension</artifactId>
+        <version>{latest version}</version>
+    </extension>
+</extensions>
+
+Your updated build configuration should be pushed before proceeding.
+
+${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Maven extension and pushed the changes.${RESTORE}
+EOF
+  print_wizard_text "${text}"
+  wait_for_enter
+}
+
+explain_prerequisites_gradle_remote_build_cache_config() {
   local text preparation_step
 
   if [ -n "$1" ]; then
@@ -116,7 +161,55 @@ EOF
   wait_for_enter
 }
 
-explain_prerequisites_empty_remote_build_cache() {
+explain_prerequisites_maven_remote_build_cache_config() {
+  local text preparation_step
+
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
+
+  IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Preparation ${preparation_step}- Configure build for remote build caching${RESTORE}
+
+You must first configure your build for remote build caching. An extract of a
+typical build configuration is described below.
+
+.mvn/gradle-enterprise.xml:
+<gradleEnterprise>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>                         <!-- must be false for this experiment -->
+    </local>
+    <remote>
+      <server>
+        <url>https://ge.example.com/cache/exp3/</url>  <!-- adjust to your GE hostname, and note the trailing slash -->
+        <allowUntrusted>true</allowUntrusted>          <!-- set to false if a trusted certificate is configured for the GE server -->
+        <credentials>
+          <username>\${env.GRADLE_ENTERPRISE_CACHE_USERNAME}</username>
+          <password>\${env.GRADLE_ENTERPRISE_CACHE_PASSWORD}</password>
+        </credentials>
+      </server>
+      <enabled>true</enabled>                          <!-- must be true for this experiment -->
+    </remote>
+  </buildCache>
+</gradleEnterprise>
+
+On CI, you will also need to pass -Dgradle.cache.remote.storeEnabled=true to the Maven invocation
+so that the CI build populates the remote build cache.
+
+Your updated build configuration needs to be pushed to a separate branch that
+is only used for running the experiments.
+
+${USER_ACTION_COLOR}Press <Enter> once you have configured your build for remote build caching and pushed the changes.${RESTORE}
+EOF
+  print_wizard_text "${text}"
+  wait_for_enter
+}
+
+explain_prerequisites_gradle_empty_remote_build_cache() {
   local text preparation_step
 
   if [ -n "$1" ]; then
@@ -160,6 +253,57 @@ triggering the build on CI. Details on how to provide the overrides are
 available from the documentation of the plugin.
 
 https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-gradle-plugin/README.md#configuration-overrides
+
+${USER_ACTION_COLOR}Press <Enter> once you have prepared the experiment to run with an empty remote build cache.${RESTORE}
+EOF
+  print_wizard_text "${text}"
+  wait_for_enter
+}
+
+explain_prerequisites_maven_empty_remote_build_cache() {
+  local text preparation_step
+
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
+
+  IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Preparation ${preparation_step}- Purge remote build cache${RESTORE}
+
+It is important to use an empty remote build cache and to avoid that other
+builds write to the same remote build cache while this experiment is running.
+Ensuring that these preconditions are met will maximize the reproducibility
+and reliability of the experiment. Two different ways to meet these conditions
+are described below.
+
+a) If none of your builds are yet writing to the remote build cache besides
+the builds of this experiment, purge the remote build cache that your build
+is configured to connect to. You can purge the remote build cache by navigating
+in the browser to the 'Build Cache' admin section from the user menu of your
+Gradle Enterprise UI, selecting the build cache node the build is pointing to,
+and then clicking the 'Purge cache' button.
+
+b) If you are not in a position to purge the remote build cache, you can connect
+to a unique shard of the remote build cache each time you run this experiment.
+A shard is accessed via an identifier that is appended to the path of the remote
+build cache URL, for example https://ge.example.com/cache/exp4-2021-Dec31-take1/
+which encodes the experiment type, the current date, and a counter that needs
+to be increased every time the experiment is rerun. Using such an encoding
+schema ensures that for each run of the experiment an empty remote build cache
+will be used. You need to push the changes to the path of the remote build cache
+URL every time before you run the experiment.
+
+If you choose option b) and do not want to interfere with an already existing
+build caching configuration in your build and you are using the Common Custom
+User Data Maven extension, you can override the local and remote build cache
+configuration via system properties or environment variables right when
+triggering the build on CI. Details on how to provide the overrides are
+available from the documentation of the extension.
+
+https://docs.gradle.com/enterprise/maven-extension/#configuring_the_remote_cache
 
 ${USER_ACTION_COLOR}Press <Enter> once you have prepared the experiment to run with an empty remote build cache.${RESTORE}
 EOF

--- a/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -103,7 +103,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 execute_first_build() {

--- a/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -254,16 +254,13 @@ local build caching and what goals executed in the second build, which of those
 goals had the biggest impact on build performance, and what caused those goals
 to not be taken from the local build cache.
 
-The ‘Command Line Invocation’ section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -71,6 +71,9 @@ wizard_execute() {
   print_introduction
 
   print_bl
+  explain_prerequisites_ccud_maven_plugin ""
+
+  print_bl
   explain_collect_git_details
   print_bl
   collect_git_details

--- a/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -71,6 +71,9 @@ wizard_execute() {
   print_introduction
 
   print_bl
+  explain_prerequisites_ccud_maven_plugin ""
+
+  print_bl
   explain_collect_git_details
   print_bl
   collect_git_details

--- a/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -294,16 +294,13 @@ local build caching and what goals executed in the second build, which of those
 goals had the biggest impact on build performance, and what caused those goals
 to not be taken from the local build cache.
 
-The ‘Command Line Invocation’ section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -106,7 +106,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 execute_first_build() {

--- a/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -458,16 +458,13 @@ remote build caching and what goals executed in the second build, which of those
 goals had the biggest impact on build performance, and what caused those goals
 to not be taken from the remote build cache.
 
-The 'Command Line Invocation' section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -63,13 +63,16 @@ wizard_execute() {
   print_introduction
 
   print_bl
-  explain_prerequisites_ccud_maven_plugin
+  explain_prerequisites_ccud_maven_plugin "I."
 
   print_bl
-  explain_prerequisites_remote_build_cache_config
+  explain_prerequisites_maven_remote_build_cache_config "II."
 
   print_bl
-  explain_prerequisites_empty_remote_build_cache
+  explain_prerequisites_maven_empty_remote_build_cache "III."
+
+  print_bl
+  explain_prerequisites_api_access "IV."
 
   print_bl
   explain_first_build
@@ -205,129 +208,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_ccud_maven_plugin() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation I. - Configure build with Common Custom User Data Maven extension${RESTORE}
-
-To get the most out of this experiment and also when building with Gradle
-Enterprise during daily development, it is advisable that you apply the Common
-Custom User Data Maven extension to your build, if not already the case. Gradle
-provides the Common Custom User Data Maven extension as a free, open-source add-on.
-
-https://github.com/gradle/gradle-enterprise-build-config-samples/tree/master/common-custom-user-data-maven-extension
-
-An extract of a typical build configuration is described below.
-
-.mvn/extensions.xml:
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-    <extension>
-        <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>{latest version}</version>
-    </extension>
-    <extension>
-        <groupId>com.gradle</groupId>
-        <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>{latest version}</version>
-    </extension>
-</extensions>
-
-Your updated build configuration should be pushed before proceeding.
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Maven extension and pushed the changes.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_remote_build_cache_config() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation II. - Configure build for remote build caching${RESTORE}
-
-You must first configure your build for remote build caching. An extract of a
-typical build configuration is described below.
-
-.mvn/gradle-enterprise.xml:
-<gradleEnterprise>
-  <buildCache>
-    <local>
-      <enabled>false</enabled>                         <!-- must be false for this experiment -->
-    </local>
-    <remote>
-      <server>
-        <url>https://ge.example.com/cache/exp3/</url>  <!-- adjust to your GE hostname, and note the trailing slash -->
-        <allowUntrusted>true</allowUntrusted>          <!-- set to false if a trusted certificate is configured for the GE server -->
-        <credentials>
-          <username>\${env.GRADLE_ENTERPRISE_CACHE_USERNAME}</username>
-          <password>\${env.GRADLE_ENTERPRISE_CACHE_PASSWORD}</password>
-        </credentials>
-      </server>
-      <enabled>true</enabled>                          <!-- must be true for this experiment -->
-    </remote>
-  </buildCache>
-</gradleEnterprise>
-
-On CI, you will also need to pass -Dgradle.cache.remote.storeEnabled=true to the Maven invocation
-so that the CI build populates the remote build cache.
-
-Your updated build configuration needs to be pushed to a separate branch that
-is only used for running the experiments.
-
-${USER_ACTION_COLOR}Press <Enter> once you have configured your build for remote build caching and pushed the changes.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_empty_remote_build_cache() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation III. - Purge remote build cache${RESTORE}
-
-It is important to use an empty remote build cache and to avoid that other
-builds write to the same remote build cache while this experiment is running.
-Ensuring that these preconditions are met will maximize the reproducibility
-and reliability of the experiment. Two different ways to meet these conditions
-are described below.
-
-a) If none of your builds are yet writing to the remote build cache besides
-the builds of this experiment, purge the remote build cache that your build
-is configured to connect to. You can purge the remote build cache by navigating
-in the browser to the 'Build Cache' admin section from the user menu of your
-Gradle Enterprise UI, selecting the build cache node the build is pointing to,
-and then clicking the 'Purge cache' button.
-
-b) If you are not in a position to purge the remote build cache, you can connect
-to a unique shard of the remote build cache each time you run this experiment.
-A shard is accessed via an identifier that is appended to the path of the remote
-build cache URL, for example https://ge.example.com/cache/exp4-2021-Dec31-take1/
-which encodes the experiment type, the current date, and a counter that needs
-to be increased every time the experiment is rerun. Using such an encoding
-schema ensures that for each run of the experiment an empty remote build cache
-will be used. You need to push the changes to the path of the remote build cache
-URL every time before you run the experiment.
-
-If you choose option b) and do not want to interfere with an already existing
-build caching configuration in your build and you are using the Common Custom
-User Data Maven extension, you can override the local and remote build cache
-configuration via system properties or environment variables right when
-triggering the build on CI. Details on how to provide the overrides are
-available from the documentation of the extension.
-
-https://docs.gradle.com/enterprise/maven-extension/#configuring_the_remote_cache
-
-${USER_ACTION_COLOR}Press <Enter> once you have prepared the experiment to run with an empty remote build cache.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -95,7 +95,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 validate_required_args() {

--- a/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -617,16 +617,13 @@ from the remote cache and what goals executed in the second build with cache
 misses, which of those goals had the biggest impact on build performance, and
 what caused the cache misses.
 
-The ‘Command Line Invocation’ section below demonstrates how you can rerun the
-experiment with the same configuration and in non-interactive mode.
+$(explain_command_to_repeat_experiment)
 
 $(print_summary)
 
 $(print_command_to_repeat_experiment)
 
-Once you have addressed the issues surfaced in build scans and pushed the
-changes to your Git repository, you can rerun the experiment and start over
-the cycle of run → measure → improve → run.
+$(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
 }

--- a/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -123,7 +123,6 @@ wizard_execute() {
   explain_measure_build_results
   print_bl
   explain_and_print_summary
-  print_bl
 }
 
 process_script_arguments() {

--- a/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -72,13 +72,16 @@ wizard_execute() {
   print_introduction
 
   print_bl
-  explain_prerequisites_ccud_maven_plugin
+  explain_prerequisites_ccud_maven_plugin "I."
 
   print_bl
-  explain_prerequisites_remote_build_cache_config
+  explain_prerequisites_maven_remote_build_cache_config "II."
 
   print_bl
-  explain_prerequisites_empty_remote_build_cache
+  explain_prerequisites_maven_empty_remote_build_cache "III."
+
+  print_bl
+  explain_prerequisites_api_access "IV."
 
   print_bl
   explain_ci_build
@@ -264,129 +267,6 @@ can push your changes and run the experiment again. This creates a cycle of run
 ${USER_ACTION_COLOR}Press <Enter> to get started with the experiment.${RESTORE}
 EOF
 
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_ccud_maven_plugin() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation I. - Configure build with Common Custom User Data Maven extension${RESTORE}
-
-To get the most out of this experiment and also when building with Gradle
-Enterprise during daily development, it is advisable that you apply the Common
-Custom User Data Maven extension to your build, if not already the case. Gradle
-provides the Common Custom User Data Maven extension as a free, open-source add-on.
-
-https://github.com/gradle/gradle-enterprise-build-config-samples/tree/master/common-custom-user-data-maven-extension
-
-An extract of a typical build configuration is described below.
-
-.mvn/extensions.xml:
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-    <extension>
-        <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>{latest version}</version>
-    </extension>
-    <extension>
-        <groupId>com.gradle</groupId>
-        <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>{latest version}</version>
-    </extension>
-</extensions>
-
-Your updated build configuration should be pushed before proceeding.
-
-${USER_ACTION_COLOR}Press <Enter> once you have (optionally) configured your build with the Common Custom User Data Maven extension and pushed the changes.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_remote_build_cache_config() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation II. - Configure build for remote build caching${RESTORE}
-
-You must first configure your build for remote build caching. An extract of a
-typical build configuration is described below.
-
-.mvn/gradle-enterprise.xml:
-<gradleEnterprise>
-  <buildCache>
-    <local>
-      <enabled>false</enabled>                         <!-- must be false for this experiment -->
-    </local>
-    <remote>
-      <server>
-        <url>https://ge.example.com/cache/exp3/</url>  <!-- adjust to your GE hostname, and note the trailing slash -->
-        <allowUntrusted>true</allowUntrusted>          <!-- set to false if a trusted certificate is configured for the GE server -->
-        <credentials>
-          <username>\${env.GRADLE_ENTERPRISE_CACHE_USERNAME}</username>
-          <password>\${env.GRADLE_ENTERPRISE_CACHE_PASSWORD}</password>
-        </credentials>
-      </server>
-      <enabled>true</enabled>                          <!-- must be true for this experiment -->
-    </remote>
-  </buildCache>
-</gradleEnterprise>
-
-On CI, you will also need to pass -Dgradle.cache.remote.storeEnabled=true to the Maven invocation
-so that the CI build populates the remote build cache.
-
-Your updated build configuration needs to be pushed to a separate branch that
-is only used for running the experiments.
-
-${USER_ACTION_COLOR}Press <Enter> once you have configured your build for remote build caching and pushed the changes.${RESTORE}
-EOF
-  print_wizard_text "${text}"
-  wait_for_enter
-}
-
-explain_prerequisites_empty_remote_build_cache() {
-  local text
-  IFS='' read -r -d '' text <<EOF
-$(print_separator)
-${HEADER_COLOR}Preparation III. - Purge remote build cache${RESTORE}
-
-It is important to use an empty remote build cache and to avoid that other
-builds write to the same remote build cache while this experiment is running.
-Ensuring that these preconditions are met will maximize the reproducibility
-and reliability of the experiment. Two different ways to meet these conditions
-are described below.
-
-a) If none of your builds are yet writing to the remote build cache besides
-the builds of this experiment, purge the remote build cache that your build
-is configured to connect to. You can purge the remote build cache by navigating
-in the browser to the 'Build Cache' admin section from the user menu of your
-Gradle Enterprise UI, selecting the build cache node the build is pointing to,
-and then clicking the 'Purge cache' button.
-
-b) If you are not in a position to purge the remote build cache, you can connect
-to a unique shard of the remote build cache each time you run this experiment.
-A shard is accessed via an identifier that is appended to the path of the remote
-build cache URL, for example https://ge.example.com/cache/exp4-2021-Dec31-take1/
-which encodes the experiment type, the current date, and a counter that needs
-to be increased every time the experiment is rerun. Using such an encoding
-schema ensures that for each run of the experiment an empty remote build cache
-will be used. You need to push the changes to the path of the remote build cache
-URL every time before you run the experiment.
-
-If you choose option b) and do not want to interfere with an already existing
-build caching configuration in your build and you are using the Common Custom
-User Data Maven extension, you can override the local and remote build cache
-configuration via system properties or environment variables right when
-triggering the build on CI. Details on how to provide the overrides are
-available from the documentation of the plugin.
-
-https://docs.gradle.com/enterprise/maven-extension/#configuring_the_remote_cache
-
-${USER_ACTION_COLOR}Press <Enter> once you have prepared the experiment to run with an empty remote build cache.${RESTORE}
-EOF
   print_wizard_text "${text}"
   wait_for_enter
 }


### PR DESCRIPTION
- Remove blank line printed at the end of interactive mode
- Deduplicate text in the explain_and_print_summary functions across the scripts
- Deduplicate CCUD Plugin preparation step explaination
- Deduplicate other gradle exp prerequisite explainatory text
- Deduplicate preparation explainatory text for Maven experiments
- Fix collecting the root dir for Maven experiments
- Fix indentation when build fails or when fetching a build scan fails
