### PR TITLE
Remove unnecessary pushd/popd

### DIFF
--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -10,10 +10,10 @@ invoke_gradle() {
   local args
   args=()
 
-  pushd "${project_dir}" > /dev/null 2>&1 || die "ERROR: The subdirectory ${project_dir} (set with --project-dir) does not exist in ${project_name}." 3
-
   local init_scripts_dir
   init_scripts_dir="$(init_scripts_path)"
+
+  pushd "${project_dir}" > /dev/null 2>&1 || die "ERROR: The subdirectory ${project_dir} (set with --project-dir) does not exist in ${project_name}." 3
 
   if [ "$enable_ge" == "on" ]; then
     args+=(--init-script "${init_scripts_dir}/enable-gradle-enterprise.gradle")

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-
+* When using the ```project-dir``` argument to specify the build invocation directory, script execution was failing due to wrong ```pushd``` ordering in ```invoke_gradle```

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-* When using the ```project-dir``` argument to specify the build invocation directory, script execution was failing due to wrong ```pushd``` ordering in ```invoke_gradle```
+* FIX: Gradle experiment scripts fail when using the ```--project-dir``` argument to specify the build invocation directory.


### PR DESCRIPTION
When using `project-dir` parameter, build fails as relative path to `init-scripts` is incorrect.
This is happening because we `pushd` twice to the `project-dir` folder
https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/bd457beeba9c57d8e8e2afcf396693e2f3be104d/components/scripts/lib/gradle.sh#L13
and then
https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/bd457beeba9c57d8e8e2afcf396693e2f3be104d/components/scripts/lib/paths.sh#L51

Signed-off-by: Jerome Prinet <jprinet@gradle.com>