### PR TITLE
Composite action to assert caching

### DIFF
--- a/.github/composite/README.md
+++ b/.github/composite/README.md
@@ -1,0 +1,67 @@
+# Composite Github Actions
+
+The composite actions provided here will simplify running the validation scripts in your Github Action workflow.
+
+## Usage
+
+Create a Github Action workflow, fulfilling the build requirements (add JDK...) and then add the following steps (replacing the placeholders):
+
+```yaml
+steps:
+  # Download scripts latest version
+  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/composite/getLatest@v1.0.2
+    with:
+      token: ${{ secrets.GITHUB_TOKEN }}
+  # Run experiment 1
+  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/composite/exp1@v1.0.2
+    with:
+      repositoryUrl: <PROJECT_GIT_URL>
+      branch: <PROJECT_BRANCH>
+      task: <PROJECT_BUILD_TASK>
+      gradleEnterpriseUrl: <GRADLE_ENTERPRISE_URL>
+  # Run experiment 2
+  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/composite/exp2@v1.0.2
+    with:
+      repositoryUrl: <PROJECT_GIT_URL>
+      branch: <PROJECT_BRANCH>
+      task: <PROJECT_BUILD_TASK>
+      gradleEnterpriseUrl: <GRADLE_ENTERPRISE_URL>
+  # Run experiment 3
+  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/composite/exp3@v1.0.2
+    with:
+      repositoryUrl: <PROJECT_GIT_URL>
+      branch: <PROJECT_BRANCH>
+      task: <PROJECT_BUILD_TASK>
+      gradleEnterpriseUrl: <GRADLE_ENTERPRISE_URL>
+```
+
+You can then navigate the workflow output and click the investigation links provided by the script.
+
+## Automated validation
+
+You may want to periodically run the experiments above and automatically check that there are no performance regressions (aka more tasks running or more cache misses than expected).
+- ```gradleEnterpriseUrl``` is the URL of your Gradle Enterprise server
+- ```token``` is the Gradle Enterprise token
+- ```buildId1``` is the first build identifier (used to check that build was successful)
+- ```buildId2``` is the second build identifier
+- ```executionStatus``` execution status, can be ```"executed_"``` to check for tasks which actually run or ```"executed_cacheable"``` if you'd like to check specifically for cacheable tasks
+- ```expectedTasks``` is the lexicographically ordered csv list of tasks which should normally match the ```executionStatus``` (can be omitted if no task should match the status)
+- ```continueOnError: true``` can optionally be set if you'd like your workflow to keep running no matter if a failure has been encountered
+
+```yaml
+  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/composite/exp1@v1.0.2
+    id: run1
+    with:
+      repositoryUrl: <PROJECT_GIT_URL>
+      branch: <PROJECT_BRANCH>
+      task: <PROJECT_BUILD_TASK>
+      gradleEnterpriseUrl: <GRADLE_ENTERPRISE_URL>
+  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/composite/assert@v1.0.2
+    with:
+      gradleEnterpriseUrl: <GRADLE_ENTERPRISE_URL>
+      token: <GRADLE_ENTERPRISE_API_KEY>
+      buildId1: ${{ steps.run1.outputs.buildScanId1 }}
+      buildId2: ${{ steps.run1.outputs.buildScanId2 }}
+      executionStatus: "executed_"
+      expectedTasks: <ORDERED_CSV_LIST>
+```

--- a/.github/composite/assert/action.yml
+++ b/.github/composite/assert/action.yml
@@ -1,0 +1,74 @@
+name: Assert caching
+description: "Assert caching"
+
+inputs:
+  gradleEnterpriseUrl:
+    description: "Gradle Enterprise URL"
+    required: true
+  token:
+    description: "API token"
+    required: true
+  buildId1:
+    description: "Build 1 identifier"
+    required: true
+  buildId2:
+    description: "Build 2 identifier"
+    required: true
+  executionStatus:
+    description: "Execution status"
+    required: true
+  expectedTasks:
+    description: "Lexicographically csv ordered list of expected tasks"
+    required: false
+    default : ""
+  # continue-on-error can't be used on a composite step
+  continueOnError:
+    description: "Whether to fail if expectation is not meet"
+    required: true
+    default : "false"
+outputs:
+  failure:
+    description: "Failure flag"
+    value: ${{ steps.run.outputs.failure }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check task count which runs
+      id: run
+      run: |
+        isFailure=false
+
+        # check build 1
+        buildHasFailed=$(curl -s -H 'Authorization: Bearer ${{ inputs.token }}' ${{ inputs.gradleEnterpriseUrl }}/api/builds/${{ inputs.buildId1 }}/gradle-attributes | jq .hasFailed)
+        if [ -z "$buildHasFailed" ] || [ "$buildHasFailed" != "false" ]; then
+          echo '::warning:: Build 1 has failed'
+          isFailure=true
+        fi
+
+        # check build 2
+        buildHasFailed=$(curl -s -H 'Authorization: Bearer ${{ inputs.token }}' ${{ inputs.gradleEnterpriseUrl }}/api/builds/${{ inputs.buildId2 }}/gradle-attributes | jq .hasFailed)
+        if [ -z "$buildHasFailed" ] || [ "$buildHasFailed" != "false" ]; then
+          echo '::warning:: Build 2 has failed'
+          isFailure=true
+        fi
+
+        if [ "$isFailure" == "false" ]; then
+          # check expectations
+          tasks=$(curl -s -H 'Authorization: Bearer ${{ inputs.token }}' ${{ inputs.gradleEnterpriseUrl }}/api/builds/${{ inputs.buildId2 }}/gradle-build-cache-performance | jq -r '[.taskExecution[] | select( .avoidanceOutcome | contains ("${{ inputs.executionStatus }}"))] | sort_by(.taskPath) | [.[].taskPath] | @csv' | tr -d \")
+          if [ "${tasks}" != "${{ inputs.expectedTasks }}" ]; then
+            echo '::warning:: Performance regression detected'
+            echo '::warning:: EXPECTED:'
+            echo '::warning:: ${{ inputs.expectedTasks }}'
+            echo '::warning:: ACTUAL:'
+            echo "::warning:: ${tasks}"
+            isFailure=true
+          fi
+        fi
+
+        echo "::set-output name=failure::$isFailure"
+
+        if [ "$isFailure" == "false" ] && [ "${{ inputs.continueOnError }}" == "false" ]; then
+          exit 1
+        fi
+      shell: bash


### PR DESCRIPTION
A composite step which can be reused in any Github workflow to check the outcome of the experiments triggered by the automated scripts.
The step checks that both builds of an experiment succeeded and that the second one is matching a number of expected tasks to run (check against GE API).

Signed-off-by: Jerome Prinet <jprinet@gradle.com>