### PR TITLE
Enable remote build caching

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+      GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_SOLUTIONS_CACHE_USERNAME }}
+      GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+      GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_SOLUTIONS_CACHE_USERNAME }}
+      GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+      GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_SOLUTIONS_CACHE_USERNAME }}
+      GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,8 +5,6 @@ plugins {
     id("com.gradle.common-custom-user-data-gradle-plugin") version "1.6.5"
 }
 
-rootProject.name = "build-validation"
-
 val isCI = System.getenv("GITHUB_ACTIONS") != null
 
 gradleEnterprise {
@@ -36,6 +34,8 @@ buildCache {
         isPush = isCI
     }
 }
+
+rootProject.name = "build-validation-scripts"
 
 include("components/capture-build-scan-url-maven-extension")
 include("components/fetch-build-scan-data-cmdline-tool")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,23 @@ gradleEnterprise {
     }
 }
 
+buildCache {
+    local {
+        isEnabled = true
+    }
+
+    remote<HttpBuildCache> {
+        url = uri("https://ge.solutions-team.gradle.com/cache/")
+        isAllowUntrustedServer = false
+        credentials {
+            username = System.getenv("GRADLE_ENTERPRISE_CACHE_USERNAME")
+            password = System.getenv("GRADLE_ENTERPRISE_CACHE_PASSWORD")
+        }
+        isEnabled = true
+        isPush = isCI
+    }
+}
+
 include("components/capture-build-scan-url-maven-extension")
 include("components/fetch-build-scan-data-cmdline-tool")
 


### PR DESCRIPTION
This change enables the remote build cache for all builds. Anonymous
users have read-only build cache access, while CI has read-write.

This change also configures GitHub actions to authenticate with the
build cache.