### PR TITLE
Enable configuration caching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,13 +93,16 @@ val copyGradleScripts = tasks.register<Copy>("copyGradleScripts") {
     group = "build"
     description = "Copies the Gradle source and generated scripts to output directory."
 
+    inputs.property("project.version", project.version)
+    val projectVersion = project.version.toString()
+
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
     rename("version.txt", "VERSION")
 
     from(layout.projectDirectory.dir("components/scripts/gradle")) {
         exclude("gradle-init-scripts")
-        filter { line: String -> line.replace("<HEAD>", "${project.version}") }
+        filter { line: String -> line.replace("<HEAD>", projectVersion) }
     }
     from(layout.projectDirectory.dir("components/scripts/gradle")) {
         include("gradle-init-scripts/**")
@@ -109,7 +112,7 @@ val copyGradleScripts = tasks.register<Copy>("copyGradleScripts") {
         include("README.md")
         include("lib/**")
         exclude("lib/cli-parsers")
-        filter { line: String -> line.replace("<HEAD>", "${project.version}") }
+        filter { line: String -> line.replace("<HEAD>", projectVersion) }
     }
     from(applyArgbash.map { it.outputDir.file("lib/cli-parsers/gradle") }) {
         into("lib/")
@@ -124,18 +127,21 @@ val copyMavenScripts = tasks.register<Copy>("copyMavenScripts") {
     group = "build"
     description = "Copies the Maven source and generated scripts to output directory."
 
+    inputs.property("project.version", project.version)
+    val projectVersion = project.version.toString()
+
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
     rename("version.txt", "VERSION")
 
     from(layout.projectDirectory.dir("components/scripts/maven")) {
-        filter { line: String -> line.replace("<HEAD>", "${project.version}") }
+        filter { line: String -> line.replace("<HEAD>", projectVersion) }
     }
     from(layout.projectDirectory.dir("components/scripts/")) {
         include("README.md")
         include("lib/**")
         exclude("lib/cli-parsers")
-        filter { line: String -> line.replace("<HEAD>", "${project.version}") }
+        filter { line: String -> line.replace("<HEAD>", projectVersion) }
     }
     from(applyArgbash.map { it.outputDir.file("lib/cli-parsers/maven") }) {
         into("lib/")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+org.gradle.unsafe.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.vfs.watch=true
 org.gradle.daemon=true
-org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true
+org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8


### PR DESCRIPTION
This change requires removing 2 invocations of `Task.project` at
execution time used to access the project version for the
`copyGradleScripts` and `copyMavenScripts` tasks