### PR TITLE
Add java toolchain support to buildSrc

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -28,10 +28,10 @@ jobs:
           git_config_global: true
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
       - name: Upgrade Wrappers
         uses: gradle/gradle-build-action@v2

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,11 @@
 plugins {
-    kotlin("jvm") version "1.5.21"
+    kotlin("jvm") version "1.6.0"
+}
+
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 repositories {


### PR DESCRIPTION
- Adding toolchain to buildSrc
- Changing existing jdk toolchain version from 8 to 11, to match Github action's provisionned version