### PR TITLE
Add "Set up Gradle" step to GHActions workflows

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Build with Gradle
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build -i
+      - name: Build with Gradle
+        run: ./gradlew build -i

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Build with Gradle
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Build with Gradle
         env:
           GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          arguments: build githubRelease -i
+        run: ./gradlew build githubRelease -i

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Build with Gradle
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Build with Gradle
         env:
           GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          arguments: build githubRelease -PfinalRelease -i
+        run: ./gradlew build githubRelease -PfinalRelease -i

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -33,9 +33,9 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Upgrade Wrappers
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: 'clean upgradeGradleWrapperAll --continue'
+      - name: Upgrade Wrappers
+        run: ./gradlew clean upgradeGradleWrapperAll --continue
         env:
           WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Separating the setup of the Gradle build tool from actual build invocation
is more idiomatic to GH Actions in general, and provides a clearer separation
of responsibilities.