### PR TITLE
Do not generate release notes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -251,6 +251,7 @@ githubRelease {
     tagName.set(gitReleaseTag())
     prerelease.set(isDevelopmentRelease)
     overwrite.set(isDevelopmentRelease)
+    generateReleaseNotes.set(false)
     body.set(layout.projectDirectory.file("release/changes.md").asFile.readText().trim())
     releaseAssets(assembleGradleScripts, assembleMavenScripts, generateChecksums.get().outputs.files.asFileTree)
 }


### PR DESCRIPTION
Bumping com.github.breadmoirai.github-release from 2.3.7 to 2.4.1 causes Github release notes to be auto-generated. This PR desactivates this to keep the previous behavior of specifying the release notes manually.