### PR TITLE
Append a trailing slash to the build cache URL

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
@@ -20,7 +20,7 @@ public enum Fields {
     GIT_COMMIT_ID("Git Commit ID", BuildValidationData::getGitCommitId),
     REQUESTED_TASKS("Requested Tasks", d -> String.join(" ", d.getRequestedTasks())),
     BUILD_OUTCOME("Build Outcome", BuildValidationData::getBuildOutcome),
-    REMOTE_BUILD_CACHE_URL("Remote Build Cache URL", d -> toStringSafely(d.getRemoteBuildCacheUrl())),
+    REMOTE_BUILD_CACHE_URL("Remote Build Cache URL", d -> toStringSafelyWithTrailingSlash(d.getRemoteBuildCacheUrl())),
     REMOTE_BUILD_CACHE_SHARD("Remote Build Cache Shard", BuildValidationData::getRemoteBuildCacheShard),
     AVOIDED_UP_TO_DATE("Avoided Up To Date", d -> totalTasks(d, "avoided_up_to_date")),
     AVOIDED_UP_TO_DATE_AVOIDANCE_SAVINGS("Avoided up-to-date avoidance savings", d -> totalAvoidanceSavings(d, "avoided_up_to_date")),
@@ -49,6 +49,14 @@ public enum Fields {
             return "";
         }
         return object.toString();
+    }
+
+    private static String toStringSafelyWithTrailingSlash(Object object) {
+        String value = toStringSafely(object);
+        if (value.isEmpty() || value.endsWith("/")) {
+            return value;
+        }
+        return value + "/";
     }
 
     private static String totalTasks(BuildValidationData data, String avoidanceOutcome) {

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
@@ -20,7 +20,7 @@ public enum Fields {
     GIT_COMMIT_ID("Git Commit ID", BuildValidationData::getGitCommitId),
     REQUESTED_TASKS("Requested Tasks", d -> String.join(" ", d.getRequestedTasks())),
     BUILD_OUTCOME("Build Outcome", BuildValidationData::getBuildOutcome),
-    REMOTE_BUILD_CACHE_URL("Remote Build Cache URL", d -> toStringSafelyWithTrailingSlash(d.getRemoteBuildCacheUrl())),
+    REMOTE_BUILD_CACHE_URL("Remote Build Cache URL", d -> toStringSafely(d.getRemoteBuildCacheUrl())),
     REMOTE_BUILD_CACHE_SHARD("Remote Build Cache Shard", BuildValidationData::getRemoteBuildCacheShard),
     AVOIDED_UP_TO_DATE("Avoided Up To Date", d -> totalTasks(d, "avoided_up_to_date")),
     AVOIDED_UP_TO_DATE_AVOIDANCE_SAVINGS("Avoided up-to-date avoidance savings", d -> totalAvoidanceSavings(d, "avoided_up_to_date")),
@@ -49,14 +49,6 @@ public enum Fields {
             return "";
         }
         return object.toString();
-    }
-
-    private static String toStringSafelyWithTrailingSlash(Object object) {
-        String value = toStringSafely(object);
-        if (value.isEmpty() || value.endsWith("/")) {
-            return value;
-        }
-        return value + "/";
     }
 
     private static String totalTasks(BuildValidationData data, String avoidanceOutcome) {

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -24,7 +24,11 @@ if (isTopLevelBuild) {
 
 URI getRemoteBuildCacheUrl() {
     def projectProperties = gradle.startParameter.projectProperties
-    new URI(projectProperties.get("com.gradle.enterprise.build_validation.remoteBuildCacheUrl"))
+    if (projectProperties.containsKey("com.gradle.enterprise.build_validation.remoteBuildCacheUrl")) {
+        return new URI(projectProperties.get("com.gradle.enterprise.build_validation.remoteBuildCacheUrl"))
+    } else {
+        return null
+    }
 }
 
 static URI withPathTrailingSlash(URI uri) {

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -9,13 +9,9 @@ if (isTopLevelBuild) {
             remote(HttpBuildCache) {
                 enabled = true
                 push = false
-                def remoteBuildCacheUrl = getRemoteBuildCacheUrl()
+                def remoteBuildCacheUrl = remoteBuildCacheUrl
                 if (remoteBuildCacheUrl) {
-                    if (remoteBuildCacheUrl.path.endsWith("/")) {
-                        url = remoteBuildCacheUrl
-                    } else {
-                        url = withPathTrailingSlash(remoteBuildCacheUrl)
-                    }
+                    url = remoteBuildCacheUrl.path.endsWith("/") ? remoteBuildCacheUrl : withPathTrailingSlash(remoteBuildCacheUrl)
                 }
             }
         }

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -20,11 +20,9 @@ if (isTopLevelBuild) {
 
 URI getRemoteBuildCacheUrl() {
     def projectProperties = gradle.startParameter.projectProperties
-    if (projectProperties.containsKey("com.gradle.enterprise.build_validation.remoteBuildCacheUrl")) {
-        return new URI(projectProperties.get("com.gradle.enterprise.build_validation.remoteBuildCacheUrl"))
-    } else {
-        return null
-    }
+    projectProperties.containsKey("com.gradle.enterprise.build_validation.remoteBuildCacheUrl")
+            ? new URI(projectProperties.get("com.gradle.enterprise.build_validation.remoteBuildCacheUrl"))
+            : null
 }
 
 static URI withPathTrailingSlash(URI uri) {

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -11,7 +11,7 @@ if (isTopLevelBuild) {
                 push = false
                 def remoteBuildCacheUrl = remoteBuildCacheUrl
                 if (remoteBuildCacheUrl) {
-                    url = remoteBuildCacheUrl.path.endsWith("/") ? remoteBuildCacheUrl : withPathTrailingSlash(remoteBuildCacheUrl)
+                    url = withPathTrailingSlash(remoteBuildCacheUrl)
                 }
             }
         }
@@ -28,5 +28,5 @@ URI getRemoteBuildCacheUrl() {
 }
 
 static URI withPathTrailingSlash(URI uri) {
-    new URI(uri.scheme, uri.userInfo, uri.host, uri.port, uri.path + "/", uri.query, uri.fragment)
+    uri.path.endsWith("/") ? uri : new URI(uri.scheme, uri.userInfo, uri.host, uri.port, uri.path + "/", uri.query, uri.fragment)
 }

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -9,11 +9,24 @@ if (isTopLevelBuild) {
             remote(HttpBuildCache) {
                 enabled = true
                 push = false
-                def projectProperties = gradle.startParameter.projectProperties
-                if (projectProperties.containsKey("com.gradle.enterprise.build_validation.remoteBuildCacheUrl")) {
-                    url = projectProperties.get("com.gradle.enterprise.build_validation.remoteBuildCacheUrl")
+                def remoteBuildCacheUrl = getRemoteBuildCacheUrl()
+                if (remoteBuildCacheUrl) {
+                    if (remoteBuildCacheUrl.path.endsWith("/")) {
+                        url = remoteBuildCacheUrl
+                    } else {
+                        url = withPathTrailingSlash(remoteBuildCacheUrl)
+                    }
                 }
             }
         }
     }
+}
+
+URI getRemoteBuildCacheUrl() {
+    def projectProperties = gradle.startParameter.projectProperties
+    new URI(projectProperties.get("com.gradle.enterprise.build_validation.remoteBuildCacheUrl"))
+}
+
+static URI withPathTrailingSlash(URI uri) {
+    new URI(uri.scheme, uri.userInfo, uri.host, uri.port, uri.path + "/", uri.query, uri.fragment)
 }


### PR DESCRIPTION
This change appends a `/` to the remote build cache URL path if one does not exist in the `configure-remote-build-caching` init script.

### Before

![image](https://user-images.githubusercontent.com/5797900/197856620-38519f5d-0434-498c-95af-0b0e42291f5f.png)

### After

![image](https://user-images.githubusercontent.com/5797900/197856434-7e4ba708-831a-404a-82c4-7f8a37d4a95c.png)

The remote build cache URL supplied to the build is unchanged from what is returned in the API (note the **_missing_** `/`).

![image](https://user-images.githubusercontent.com/5797900/197857518-f9927fac-6451-47eb-9184-1357c3f62e5e.png)

Fixes #155 