### PR TITLE
Add `-o`/`--git-options`

### DIFF
--- a/components/scripts/lib/cli-parsers/common.m4
+++ b/components/scripts/lib/cli-parsers/common.m4
@@ -3,6 +3,7 @@
 # ARG_OPTIONAL_BOOLEAN([enable-gradle-enterprise],[e],[])
 # ARG_OPTIONAL_SINGLE([git-branch],[b],[])
 # ARG_OPTIONAL_SINGLE([git-commit-id],[c],[])
+# ARG_OPTIONAL_SINGLE([git-options],[o],[])
 # ARG_OPTIONAL_SINGLE([gradle-enterprise-server],[s],[],[])
 # ARG_OPTIONAL_SINGLE([git-repo],[r],[])
 # ARG_OPTIONAL_SINGLE([project-dir],[p],[],[])

--- a/components/scripts/lib/cli-parsers/gradle/01-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/01-cli-parser.m4
@@ -21,6 +21,7 @@ function print_help() {
   print_option_usage -r
   print_option_usage -b
   print_option_usage -c
+  print_option_usage -o
   print_option_usage -p
   print_option_usage -t
   print_option_usage -a

--- a/components/scripts/lib/cli-parsers/gradle/02-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/02-cli-parser.m4
@@ -20,6 +20,7 @@ function print_help() {
   print_option_usage -r
   print_option_usage -b
   print_option_usage -c
+  print_option_usage -o
   print_option_usage -p
   print_option_usage -t
   print_option_usage -a

--- a/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
@@ -20,6 +20,7 @@ function print_help() {
   print_option_usage -r
   print_option_usage -b
   print_option_usage -c
+  print_option_usage -o
   print_option_usage -p
   print_option_usage -t
   print_option_usage -a

--- a/components/scripts/lib/cli-parsers/gradle/05-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/05-cli-parser.m4
@@ -25,6 +25,7 @@ function print_help() {
   print_option_usage -r
   print_option_usage -b
   print_option_usage -c
+  print_option_usage -o
   print_option_usage -p
   print_option_usage -t
   print_option_usage -a

--- a/components/scripts/lib/cli-parsers/maven/01-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/maven/01-cli-parser.m4
@@ -20,6 +20,7 @@ function print_help() {
   print_option_usage -r
   print_option_usage -b
   print_option_usage -c
+  print_option_usage -o
   print_option_usage -p
   print_option_usage -g
   print_option_usage -a

--- a/components/scripts/lib/cli-parsers/maven/02-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/maven/02-cli-parser.m4
@@ -20,6 +20,7 @@ function print_help() {
   print_option_usage -r
   print_option_usage -b
   print_option_usage -c
+  print_option_usage -o
   print_option_usage -p
   print_option_usage -g
   print_option_usage -a

--- a/components/scripts/lib/cli-parsers/maven/04-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/maven/04-cli-parser.m4
@@ -25,6 +25,7 @@ function print_help() {
   print_option_usage -r
   print_option_usage -b
   print_option_usage -c
+  print_option_usage -o
   print_option_usage -p
   print_option_usage -g
   print_option_usage -a

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -149,6 +149,7 @@ collect_git_commit_id() {
 collect_git_options() {
    local default_git_options="<none>"
    prompt_for_setting "What are additional options to use when cloning the Git repository?" "${git_options}" "${default_git_options}" git_options
+   
    if [[ "${git_options}" == "${default_git_options}" ]]; then
      git_options=''
    fi

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -17,6 +17,10 @@ process_arguments() {
     git_commit_id="${_arg_git_commit_id}"
   fi
 
+  if [ -n "${_arg_git_options+x}" ]; then
+    git_options="${_arg_git_options}"
+  fi
+
   if [ -n "${_arg_project_dir+x}" ]; then
     project_dir="${_arg_project_dir}"
   fi
@@ -116,6 +120,7 @@ collect_git_details() {
   collect_git_repo
   collect_git_branch
   collect_git_commit_id
+  collect_git_options
 }
 
 collect_git_repo() {
@@ -140,6 +145,14 @@ collect_git_commit_id() {
     git_commit_id=''
   fi
 }
+
+collect_git_options() {
+   local default_git_options="<none>"
+   prompt_for_setting "What are additional options to use when cloning the Git repository?" "${git_options}" "${default_git_options}" git_options
+   if [[ "${git_options}" == "${default_git_options}" ]]; then
+     git_options=''
+   fi
+ }
 
 collect_gradle_details() {
   collect_root_project_directory

--- a/components/scripts/lib/git.sh
+++ b/components/scripts/lib/git.sh
@@ -24,8 +24,12 @@ git_clone_project() {
    fi
 
    rm -rf "${clone_dir:?}"
-   # shellcheck disable=SC2086  # we want $branch to expand into multiple arguments
-   git clone --depth=1 ${branch} "${git_repo}" "${clone_dir}" || die "ERROR: Unable to clone from ${git_repo}." 2
+
+   # shellcheck disable=SC2086  # we want $git_options and $branch to expand into multiple arguments
+   debug git clone --depth=1 ${git_options} ${branch} "${git_repo}" "${clone_dir}"
+
+   # shellcheck disable=SC2086  # we want $git_options and $branch to expand into multiple arguments
+   git clone --depth=1 ${git_options} ${branch} "${git_repo}" "${clone_dir}" || die "ERROR: Unable to clone from ${git_repo}." 2
    cd "${clone_dir}" || die "Unable to access git repository directory ${clone_dir}." 2
 }
 

--- a/components/scripts/lib/help.sh
+++ b/components/scripts/lib/help.sh
@@ -33,6 +33,9 @@ print_option_usage() {
     -m)
        _print_option_usage "-m, --mapping-file" "Specifies the mapping file for the custom value names used in the build scans."
        ;;
+    -o)
+       _print_option_usage "-o, --git-options" "Specifies additional arguments use when cloning the Git repository."
+       ;;
     -p)
        _print_option_usage "-p, --project-dir" "Specifies the build invocation directory within the Git repository."
        ;;

--- a/components/scripts/lib/help.sh
+++ b/components/scripts/lib/help.sh
@@ -18,6 +18,9 @@ print_option_usage() {
     -c)
        _print_option_usage "-c, --git-commit-id" "Specifies the Git commit id for the Git repository to validate."
        ;;
+    -o)
+       _print_option_usage "-o, --git-options" "Specifies additional arguments use when cloning the Git repository."
+       ;;
     -e)
        _print_option_usage "-e, --enable-gradle-enterprise" "Enables Gradle Enterprise on a project not already connected."
        ;;
@@ -32,9 +35,6 @@ print_option_usage() {
        ;;
     -m)
        _print_option_usage "-m, --mapping-file" "Specifies the mapping file for the custom value names used in the build scans."
-       ;;
-    -o)
-       _print_option_usage "-o, --git-options" "Specifies additional arguments use when cloning the Git repository."
        ;;
     -p)
        _print_option_usage "-p, --project-dir" "Specifies the build invocation directory within the Git repository."


### PR DESCRIPTION
This PR adds the ability to supply additional options the `git clone` by use  of the `--git-options` parameter, or `-o` for short.

Example:

```shell
./01-validate-incremental-building.sh  --git-options '--depth=9999' --tasks build -r 'git@github.com:gradle/gradle-enterprise-build-validation-scripts.git'
```

Experiments affected:
- Gradle: 1, 2, 3, & 5
- Maven: 1, 2, & 4

Notes/questions:
- When checking out a specific commit, which occurs when `--git-commit` is used or always in gradle-exp5 and maven-exp4(?), we `fetch` instead of a `clone`. Should we also supply the value of `--git-options` to `fetch`?
- The common case of wanting to perform a full clone is not directly supported by this change. We are already using `--depth=1` when we `clone` with no way to remove it. A workaround for this is to call the script with `--git-options '--depth=99999'`.