### PR TITLE
Print `<not available>` for Git options on exp4-gradle and exp3-maven

### DIFF
--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -31,6 +31,7 @@ source "${LIB_DIR}/libs.sh" || { echo -e "\033[00;31m\033[1mERROR: Couldn't find
 git_repo=''
 project_name=''
 git_branch=''
+git_options='<not available>'
 project_dir='<not available>'
 extra_args='<not available>'
 tasks=''

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -31,6 +31,7 @@ source "${LIB_DIR}/libs.sh" || { echo -e "\033[00;31m\033[1mERROR: Couldn't find
 git_repo=''
 project_name=''
 git_branch=''
+git_options='<not available>'
 project_dir='<not available>'
 extra_args='<not available>'
 tasks=''


### PR DESCRIPTION
Previously on Maven experiment 3 and Gradle experiment 4 the Git options would be displayed as `<unknown>`. This change sets the Git options to display as `<not available>` in order to be consistent with other options printed in the summary.

## Testing

### Before

![image](https://user-images.githubusercontent.com/5797900/198384673-b0f9f7f5-786c-4f5d-ac0c-b274f5f03824.png)

### After

#### Gradle

```
./04-validate-remote-build-caching-ci-ci.sh \
  -1 'https://ge.solutions-team.gradle.com/s/6x7tulbxvdt66' \
  -2 'https://ge.solutions-team.gradle.com/s/xm7udfl7jp4hs'
```

![image](https://user-images.githubusercontent.com/5797900/198385289-bd92ce17-202d-464c-9369-9bbcc6a626d0.png)

#### Maven

```
./03-validate-remote-build-caching-ci-ci.sh \
  -1 'https://ge.solutions-team.gradle.com/s/ed6a3h7m3swpa' \
  -2 'https://ge.solutions-team.gradle.com/s/eq5u5tbq6xdyo'
```

![image](https://user-images.githubusercontent.com/5797900/198385404-bd5dfe2b-92e0-4e51-935c-c72201f0bb6d.png)
