### PR TITLE
Fix --no-build-scan-publishing

### DIFF
--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -38,7 +38,7 @@ ge_server=''
 interactive_mode=''
 
 main() {
-  if [[ "$no_build_scan_publishing_mode" == "on" ]]; then
+  if [[ "$build_scan_publishing_mode" == "off" ]]; then
     debug "Running experiment with Build Scan publishing disabled."
   fi
 

--- a/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034  # It is common for variables in this auto-generated file to go unused
 # Created by argbash-init v2.10.0
+# ARG_OPTIONAL_BOOLEAN([build-scan-publishing],[],[],[on])
 # ARG_OPTIONAL_BOOLEAN([fail-if-not-fully-cacheable],[f],[])
-# ARG_OPTIONAL_BOOLEAN([no-build-scan-publishing],[],[],[off])
 # ARG_HELP([This function is overridden later on.])
 # ARG_VERSION([print_version],[v],[version],[])
 # ARGBASH_WRAP([common])

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -59,8 +59,10 @@ process_arguments() {
     fail_if_not_fully_cacheable="${_arg_fail_if_not_fully_cacheable}"
   fi
 
-  if [ -n "${_arg_no_build_scan_publishing+x}" ]; then
-    no_build_scan_publishing_mode="${_arg_no_build_scan_publishing}"
+  if [ -n "${_arg_build_scan_publishing+x}" ]; then
+    build_scan_publishing_mode="${_arg_build_scan_publishing}"
+  else
+    build_scan_publishing_mode=on
   fi
 
   if [ -n "${_arg_interactive+x}" ]; then
@@ -272,7 +274,7 @@ print_command_to_repeat_experiment() {
     cmd+=("-f")
   fi
 
-  if [[ "${no_build_scan_publishing_mode}" == "on" ]]; then
+  if [[ "${build_scan_publishing_mode}" == "off" ]]; then
     cmd+=("--no-build-scan-publishing")
   fi
 


### PR DESCRIPTION
The `--no` prefix was confusing Argbash, which supports turning boolean flags
off with `--no-` prefixes.  The solution is to define a `build-scan-publishing`
flag instead, but default it to 'on'.
