### PR TITLE
Adjust experiment summary for --no-build-scan-published

### DIFF
--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -327,9 +327,7 @@ two build scans that were published as part of running the experiment. The build
 scan of the second build is particularly interesting since this is where you can
 inspect what tasks were not leveraging the local build cache.
 
-The ‘Build Caching Leverage’ section below reveals the realized and potential
-savings from build caching. All cacheable tasks' outputs need to be taken from
-the build cache in the second build for the build to be fully cacheable.
+$(explain_build_cache_leverage)
 
 The ‘Investigation Quick Links’ section below allows quick navigation to the
 most relevant views in build scans to investigate what tasks were avoided due to
@@ -349,9 +347,7 @@ EOF
     IFS='' read -r -d '' text <<EOF
 The ‘Summary’ section below captures the configuration of the experiment.
 
-The ‘Build Caching Leverage’ section below reveals the realized and potential
-savings from build caching. All cacheable tasks' outputs need to be taken from
-the build cache in the second build for the build to be fully cacheable.
+$(explain_build_cache_leverage)
 
 $(explain_command_to_repeat_experiment)
 
@@ -364,6 +360,17 @@ EOF
   fi
   print_wizard_text "${text}"
 }
+
+explain_build_cache_leverage() {
+  local text
+  IFS='' read -r -d '' text <<EOF
+The ‘Build Caching Leverage’ section below reveals the realized and potential
+savings from build caching. All cacheable tasks' outputs need to be taken from
+the build cache in the second build for the build to be fully cacheable.
+EOF
+  echo -n "${text}"
+}
+
 
 process_arguments "$@"
 main

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -349,8 +349,7 @@ inspect what tasks were not leveraging the local build cache.
 EOF
   else
     IFS='' read -r -d '' text <<EOF
-The ‘Summary’ section below captures the configuration of the experiment and the
-two build scans that were published as part of running the experiment.
+The ‘Summary’ section below captures the configuration of the experiment.
 EOF
   fi
   echo -n "${text}"

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -320,20 +320,12 @@ explain_and_print_summary() {
   read_build_scan_metadata
   local text
   IFS='' read -r -d '' text <<EOF
-The ‘Summary’ section below captures the configuration of the experiment and the
-two build scans that were published as part of running the experiment. The build
-scan of the second build is particularly interesting since this is where you can
-inspect what tasks were not leveraging the local build cache.
+$(explain_summary)
 
 The ‘Build Caching Leverage’ section below reveals the realized and potential
 savings from build caching. All cacheable tasks' outputs need to be taken from
 the build cache in the second build for the build to be fully cacheable.
-
-The ‘Investigation Quick Links’ section below allows quick navigation to the
-most relevant views in build scans to investigate what tasks were avoided due to
-local build caching and what tasks executed in the second build, which of those
-tasks had the biggest impact on build performance, and what caused those tasks
-to not be taken from the local build cache.
+$(explain_quick_links)
 
 $(explain_command_to_repeat_experiment)
 
@@ -344,6 +336,40 @@ $(print_command_to_repeat_experiment)
 $(explain_when_to_rerun_experiment)
 EOF
   print_wizard_text "${text}"
+}
+
+explain_summary() {
+  local text
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    IFS='' read -r -d '' text <<EOF
+The ‘Summary’ section below captures the configuration of the experiment and the
+two build scans that were published as part of running the experiment. The build
+scan of the second build is particularly interesting since this is where you can
+inspect what tasks were not leveraging the local build cache.
+EOF
+  else
+    IFS='' read -r -d '' text <<EOF
+The ‘Summary’ section below captures the configuration of the experiment and the
+two build scans that were published as part of running the experiment.
+EOF
+  fi
+  echo -n "${text}"
+}
+
+
+explain_quick_links() {
+  local text
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    IFS='' read -r -d '' text <<EOF
+
+The ‘Investigation Quick Links’ section below allows quick navigation to the
+most relevant views in build scans to investigate what tasks were avoided due to
+local build caching and what tasks executed in the second build, which of those
+tasks had the biggest impact on build performance, and what caused those tasks
+to not be taken from the local build cache.
+EOF
+    echo -n "${text}"
+  fi
 }
 
 process_arguments "$@"

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -319,13 +319,23 @@ EOF
 explain_and_print_summary() {
   read_build_scan_metadata
   local text
-  IFS='' read -r -d '' text <<EOF
-$(explain_summary)
+
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    IFS='' read -r -d '' text <<EOF
+The ‘Summary’ section below captures the configuration of the experiment and the
+two build scans that were published as part of running the experiment. The build
+scan of the second build is particularly interesting since this is where you can
+inspect what tasks were not leveraging the local build cache.
 
 The ‘Build Caching Leverage’ section below reveals the realized and potential
 savings from build caching. All cacheable tasks' outputs need to be taken from
 the build cache in the second build for the build to be fully cacheable.
-$(explain_quick_links)
+
+The ‘Investigation Quick Links’ section below allows quick navigation to the
+most relevant views in build scans to investigate what tasks were avoided due to
+local build caching and what tasks executed in the second build, which of those
+tasks had the biggest impact on build performance, and what caused those tasks
+to not be taken from the local build cache.
 
 $(explain_command_to_repeat_experiment)
 
@@ -335,40 +345,24 @@ $(print_command_to_repeat_experiment)
 
 $(explain_when_to_rerun_experiment)
 EOF
-  print_wizard_text "${text}"
-}
-
-explain_summary() {
-  local text
-  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
-    IFS='' read -r -d '' text <<EOF
-The ‘Summary’ section below captures the configuration of the experiment and the
-two build scans that were published as part of running the experiment. The build
-scan of the second build is particularly interesting since this is where you can
-inspect what tasks were not leveraging the local build cache.
-EOF
   else
     IFS='' read -r -d '' text <<EOF
 The ‘Summary’ section below captures the configuration of the experiment.
+
+The ‘Build Caching Leverage’ section below reveals the realized and potential
+savings from build caching. All cacheable tasks' outputs need to be taken from
+the build cache in the second build for the build to be fully cacheable.
+
+$(explain_command_to_repeat_experiment)
+
+$(print_summary)
+
+$(print_command_to_repeat_experiment)
+
+$(explain_when_to_rerun_experiment)
 EOF
   fi
-  echo -n "${text}"
-}
-
-
-explain_quick_links() {
-  local text
-  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
-    IFS='' read -r -d '' text <<EOF
-
-The ‘Investigation Quick Links’ section below allows quick navigation to the
-most relevant views in build scans to investigate what tasks were avoided due to
-local build caching and what tasks executed in the second build, which of those
-tasks had the biggest impact on build performance, and what caused those tasks
-to not be taken from the local build cache.
-EOF
-    echo -n "${text}"
-  fi
+  print_wizard_text "${text}"
 }
 
 process_arguments "$@"

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -49,7 +49,7 @@ invoke_gradle() {
       build_outcomes+=("FAILED")
   fi
 
-  if [ -f "${EXP_DIR}/build-scan-publish-error.txt" ]; then
+  if [ -f "${EXP_DIR}/build-scan-publish-error.txt" ] && [[ "${build_scan_publishing_mode}" == "on" ]]; then
     die "ERROR: The experiment cannot continue because publishing the build scan failed."
   fi
 

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -101,8 +101,11 @@ print_summary() {
   print_build_scans
   print_warnings
   print_performance_metrics
-  print_bl
-  print_quick_links
+
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    print_bl
+    print_quick_links
+  fi
 }
 
 print_experiment_info() {
@@ -204,12 +207,16 @@ warn_if_nonzero() {
 
 print_build_scans() {
   for (( i=0; i<2; i++ )); do
-    if [ -z "${build_outcomes[i]}" ]; then
-      summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]:+${build_scan_urls[i]} }BUILD SCAN DATA FETCH FAILED${RESTORE}"
-    elif [[ "${build_outcomes[i]}" == "FAILED" ]]; then
-      summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]:+${build_scan_urls[i]} }FAILED${RESTORE}"
+    if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+      if [ -z "${build_outcomes[i]}" ]; then
+        summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]:+${build_scan_urls[i]} }BUILD SCAN DATA FETCH FAILED${RESTORE}"
+      elif [[ "${build_outcomes[i]}" == "FAILED" ]]; then
+        summary_row "Build scan ${ORDINALS[i]} build:" "${WARN_COLOR}${build_scan_urls[i]:+${build_scan_urls[i]} }FAILED${RESTORE}"
+      else
+        summary_row "Build scan ${ORDINALS[i]} build:" "${build_scan_urls[i]}"
+      fi
     else
-      summary_row "Build scan ${ORDINALS[i]} build:" "${build_scan_urls[i]}"
+      summary_row "Build scan ${ORDINALS[i]} build:" "Build scan publishing is disabled"
     fi
   done
 }


### PR DESCRIPTION
Summary when `--no-build-scan-publishing` is passed:

```
Summary
-------
Project:                      java-ordered-properties
Git repo:                     https://github.com/etiennestuder/java-ordered-properties
Git branch:                   ge
Git commit id:                b471d917952df7fcc2fab937d404365c4e3e4b4f
Git options:                  --depth=1
Project dir:                  <root directory>
Gradle tasks:                 assemble
Gradle arguments:             <none>
Experiment:                   03 Validate local build caching - different project locations
Experiment id:                exp3-gradle
Experiment run id:            635c2803
Experiment artifact dir:      .data/03-validate-local-build-caching-different-locations/20221028T150539-635c2803
Build scan first build:       Build scan publishing is disabled
Build scan second build:      Build scan publishing is disabled

Build Caching Leverage
----------------------
Avoided cacheable tasks:      1 tasks, 0.069s total saved execution time
Executed cacheable tasks:     0 tasks, 0.000s total execution time
Executed non-cacheable tasks: 1 tasks, 0.006s total execution time
```

Summary and explanation when `--no-build-scan-published` with interactive mode:

```
The ‘Summary’ section below captures the configuration of the experiment.

The ‘Build Caching Leverage’ section below reveals the realized and potential
savings from build caching. All cacheable tasks' outputs need to be taken from
the build cache in the second build for the build to be fully cacheable.

The 'Command Line Invocation' section below demonstrates how you can rerun the
experiment with the same configuration and in non-interactive mode.

Summary
-------
Project:                      java-ordered-properties
Git repo:                     https://github.com/etiennestuder/java-ordered-properties
Git branch:                   ge
Git commit id:                b471d917952df7fcc2fab937d404365c4e3e4b4f
Git options:                  --depth=1
Project dir:                  <root directory>
Gradle tasks:                 assemble
Gradle arguments:             <none>
Experiment:                   03 Validate local build caching - different project locations
Experiment id:                exp3-gradle
Experiment run id:            635c2803
Experiment artifact dir:      .data/03-validate-local-build-caching-different-locations/20221028T150539-635c2803
Build scan first build:       Build scan publishing is disabled
Build scan second build:      Build scan publishing is disabled

Build Caching Leverage
----------------------
Avoided cacheable tasks:      1 tasks, 0.069s total saved execution time
Executed cacheable tasks:     0 tasks, 0.000s total execution time
Executed non-cacheable tasks: 1 tasks, 0.006s total execution time

Command Line Invocation
-----------------------
./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties -b ge -t assemble -a -Dscan.dump -s https://0.0.0.0 --no-build-scan-publishing

Once you have addressed the issues surfaced in build scans and pushed the
changes to your Git repository, you can rerun the experiment and start over
the cycle of run → measure → improve → run.
```