### PR TITLE
Use Build Scan dumps when publishing is disabled for Gradle experiment 3

### DIFF
--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -19,6 +19,7 @@ readonly SCRIPT_NAME
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo .)")"; pwd)"
 readonly SCRIPT_DIR
 readonly LIB_DIR="${SCRIPT_DIR}/lib"
+readonly SCANS_SUPPORT_TOOLS_JAR="${SCRIPT_DIR}/scans-support-tools.jar"
 
 # Include and parse the command line arguments
 # shellcheck source=lib/03-cli-parser.sh
@@ -38,6 +39,10 @@ ge_server=''
 interactive_mode=''
 
 main() {
+  if [[ "$build_scan_publishing_mode" == "off" ]]; then
+    verify_scans_support_tools
+  fi
+
   if [ "${interactive_mode}" == "on" ]; then
     wizard_execute
   else
@@ -45,6 +50,12 @@ main() {
   fi
   create_receipt_file
   exit_with_return_code
+}
+
+verify_scans_support_tools() {
+  if [ ! -f "$SCANS_SUPPORT_TOOLS_JAR" ]; then
+    die "ERROR: scans-support-tools.jar is required when running with --no-build-scan-publishing."
+  fi
 }
 
 execute() {

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -58,7 +58,7 @@ main() {
 
 verify_scans_support_tools() {
   if [ ! -f "$SCANS_SUPPORT_TOOLS_JAR" ]; then
-    die "ERROR: scans-support-tools.jar is required when running with --no-build-scan-publishing."
+    die "ERROR: scans-support-tools.jar is required when running with --disable-build-scan-publishing."
   fi
 }
 

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -38,7 +38,7 @@ enable_ge=''
 ge_server=''
 interactive_mode=''
 
-# Used with Build Scan publishing disabled
+# Used when Build Scan publishing is disabled
 first_build_scan_dump=''
 second_build_scan_dump=''
 

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -146,7 +146,7 @@ execute_first_build() {
   local init_scripts_dir
   init_scripts_dir="$(init_scripts_path)"
 
-  info "./gradlew --build-cache --scan -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} clean ${tasks}$(print_extra_args)"
+  print_gradle_command
 
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
   invoke_gradle \
@@ -163,13 +163,21 @@ execute_second_build() {
   local init_scripts_dir
   init_scripts_dir="$(init_scripts_path)"
 
-  info "./gradlew --build-cache --scan -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} clean ${tasks}$(print_extra_args)"
+  print_gradle_command
 
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
   invoke_gradle \
      --build-cache \
      --init-script "${init_scripts_dir}/configure-local-build-caching.gradle" \
      clean ${tasks}
+}
+
+print_gradle_command() {
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    info "./gradlew --build-cache --scan -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} clean ${tasks}$(print_extra_args)"
+  else
+    info "./gradlew --build-cache -Dscan.dump -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} clean ${tasks}$(print_extra_args)"
+  fi
 }
 
 fetch_build_cache_metrics() {

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -190,7 +190,7 @@ find_build_scan_dumps() {
 find_build_scan_dump() {
   local build_name="$1"
   local build_dir="${EXP_DIR}/$build_name-build_${project_name}"
-  build_scan_dump="$(find "$build_dir" -maxdepth 1 -type f -regex '^.*build-scan-.*-.*-.*-.*\.scan')"
+  build_scan_dump="$(find "$build_dir" -maxdepth 1 -type f -regex '^.*build-scan-.*-.*-.*-.*\.scan' | sort | tail -n 1)"
   if [ -z "$build_scan_dump" ]; then
     die "ERROR: No Build Scan dump found for the $build_name build"
   fi

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -190,7 +190,7 @@ find_build_scan_dumps() {
 find_build_scan_dump() {
   local build_name="$1"
   local build_dir="${EXP_DIR}/$build_name-build_${project_name}"
-  build_scan_dump="$(find "$build_dir" -maxdepth 1 -regex '^.*build-scan.*\.scan$')"
+  build_scan_dump="$(find "$build_dir" -maxdepth 1 -type f -regex '^.*build-scan-.*-.*-.*-.*\.scan')"
   if [ -z "$build_scan_dump" ]; then
     die "ERROR: No Build Scan dump found for the $build_name build"
   fi

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -199,8 +199,10 @@ find_build_scan_dump() {
 
 read_build_scan_dumps() {
   local build_scan_csv
+  echo -n "Extracting build scan data"
   build_scan_csv="$(invoke_java "$SCANS_SUPPORT_TOOLS_JAR" extract "$first_build_scan_dump" "$second_build_scan_dump")"
   parse_build_scan_csv "$build_scan_csv"
+  echo ", done."
 }
 
 # Overrides info.sh#print_performance_metrics

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -39,8 +39,7 @@ ge_server=''
 interactive_mode=''
 
 # Used when Build Scan publishing is disabled
-first_build_scan_dump=''
-second_build_scan_dump=''
+build_scan_dumps=()
 
 main() {
   if [[ "$build_scan_publishing_mode" == "off" ]]; then
@@ -202,13 +201,13 @@ find_build_scan_dump() {
   if [ -z "$build_scan_dump" ]; then
     die "ERROR: No Build Scan dump found for the $build_name build"
   fi
-  eval "${build_name}_build_scan_dump=\${build_scan_dump}"
+  build_scan_dumps+=("${build_scan_dump}")
 }
 
 read_build_scan_dumps() {
   local build_scan_csv
   echo -n "Extracting build scan data"
-  build_scan_csv="$(invoke_java "$SCANS_SUPPORT_TOOLS_JAR" extract "$first_build_scan_dump" "$second_build_scan_dump")"
+  build_scan_csv="$(invoke_java "$SCANS_SUPPORT_TOOLS_JAR" extract "${build_scan_dumps[0]}"  "${build_scan_dumps[1]}")"
   parse_build_scan_csv "$build_scan_csv"
   echo ", done."
 }

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -19,7 +19,7 @@ readonly SCRIPT_NAME
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo .)")"; pwd)"
 readonly SCRIPT_DIR
 readonly LIB_DIR="${SCRIPT_DIR}/lib"
-readonly SCANS_SUPPORT_TOOLS_JAR="${SCRIPT_DIR}/scans-support-tools.jar"
+readonly BUILD_SCAN_SUPPORT_TOOL_JAR="${SCRIPT_DIR}/build-scan-support-tool.jar"
 
 # Include and parse the command line arguments
 # shellcheck source=lib/03-cli-parser.sh
@@ -43,7 +43,7 @@ build_scan_dumps=()
 
 main() {
   if [[ "$build_scan_publishing_mode" == "off" ]]; then
-    verify_scans_support_tools
+    verify_build_scan_support_tool_exists
   fi
 
   if [ "${interactive_mode}" == "on" ]; then
@@ -55,9 +55,9 @@ main() {
   exit_with_return_code
 }
 
-verify_scans_support_tools() {
-  if [ ! -f "$SCANS_SUPPORT_TOOLS_JAR" ]; then
-    die "ERROR: scans-support-tools.jar is required when running with --disable-build-scan-publishing."
+verify_build_scan_support_tool_exists() {
+  if [ ! -f "$BUILD_SCAN_SUPPORT_TOOL_JAR" ]; then
+    die "ERROR: build-scan-support-tool.jar is required when using --disable-build-scan-publishing."
   fi
 }
 
@@ -207,7 +207,7 @@ find_build_scan_dump() {
 read_build_scan_dumps() {
   local build_scan_csv
   echo -n "Extracting build scan data"
-  build_scan_csv="$(invoke_java "$SCANS_SUPPORT_TOOLS_JAR" extract "${build_scan_dumps[0]}"  "${build_scan_dumps[1]}")"
+  build_scan_csv="$(invoke_java "$BUILD_SCAN_SUPPORT_TOOL_JAR" extract "${build_scan_dumps[0]}"  "${build_scan_dumps[1]}")"
   parse_build_scan_csv "$build_scan_csv"
   echo ", done."
 }

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -183,17 +183,18 @@ fetch_build_cache_metrics() {
 }
 
 find_build_scan_dumps() {
-  local first_build_dir="${EXP_DIR}/first-build_${project_name}"
-  first_build_scan_dump="$(find "$first_build_dir" -maxdepth 1 -regex '^.*build-scan.*\.scan$')"
-  if [ -z "$first_build_scan_dump" ]; then
-    die "ERROR: No Build Scan dump found for the first build"
-  fi
+  find_build_scan_dump "first"
+  find_build_scan_dump "second"
+}
 
-  local second_build_dir="${EXP_DIR}/second-build_${project_name}"
-  second_build_scan_dump="$(find "$second_build_dir" -maxdepth 1 -regex '^.*build-scan.*\.scan$')"
-  if [ -z "$second_build_scan_dump" ]; then
-    die "ERROR: No Build Scan dump found for the second build"
+find_build_scan_dump() {
+  local build_name="$1"
+  local build_dir="${EXP_DIR}/$build_name-build_${project_name}"
+  build_scan_dump="$(find "$build_dir" -maxdepth 1 -regex '^.*build-scan.*\.scan$')"
+  if [ -z "$build_scan_dump" ]; then
+    die "ERROR: No Build Scan dump found for the $build_name build"
   fi
+  eval "${build_name}_build_scan_dump=\${build_scan_dump}"
 }
 
 read_build_scan_dumps() {

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -28,10 +28,10 @@ invoke_gradle() {
     args+=("-Pcom.gradle.enterprise.build_validation.server=https://0.0.0.0")
   fi
 
-  if [ "$build_scan_publishing_mode" == "off" ]; then
-    args+=("-Dscan.dump")
-  else
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
     args+=("--scan")
+  else
+    args+=("-Dscan.dump")
   fi
 
   args+=(

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -19,6 +19,10 @@ invoke_gradle() {
     args+=(--init-script "${init_scripts_dir}/enable-gradle-enterprise.gradle")
   fi
 
+  if [ "$build_scan_publishing_mode" == "off" ]; then
+    args+=("-Dscan.dump")
+  fi
+
   args+=(--init-script "${init_scripts_dir}/configure-gradle-enterprise.gradle")
   args+=(--init-script "${init_scripts_dir}/capture-published-build-scan.gradle")
 

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -19,10 +19,6 @@ invoke_gradle() {
     args+=(--init-script "${init_scripts_dir}/enable-gradle-enterprise.gradle")
   fi
 
-  if [ "$build_scan_publishing_mode" == "off" ]; then
-    args+=("-Dscan.dump")
-  fi
-
   args+=(--init-script "${init_scripts_dir}/configure-gradle-enterprise.gradle")
   args+=(--init-script "${init_scripts_dir}/capture-published-build-scan.gradle")
 
@@ -32,8 +28,13 @@ invoke_gradle() {
     args+=("-Pcom.gradle.enterprise.build_validation.server=https://0.0.0.0")
   fi
 
+  if [ "$build_scan_publishing_mode" == "off" ]; then
+    args+=("-Dscan.dump")
+  else
+    args+=("--scan")
+  fi
+
   args+=(
-    --scan
     -Pcom.gradle.enterprise.build_validation.experimentDir="${EXP_DIR}"
     -Pcom.gradle.enterprise.build_validation.expId="${EXP_SCAN_TAG}"
     -Pcom.gradle.enterprise.build_validation.runId="${RUN_ID}"


### PR DESCRIPTION
### How to test this

1. Checkout this branch `erichaagdev/parse-scan-dump`
2. Run `./gradlew clean build`
3. `cd build/distributions`
4. `unzip gradle-enterprise-gradle-build-validation-dev.zip`
5. `cd gradle-enterprise-gradle-build-validation`
6. Download a copy of the `build-scan-support-tool.jar` and place it in the current directory. It must be named exactly `build-scan-support-tool.jar`.
7. Run! 

```shell
./03-validate-local-build-caching-different-locations.sh \
  --git-repo 'https://github.com/etiennestuder/java-ordered-properties' \
  --git-branch ge \
  --tasks build \
  --disable-build-scan-publishing
```

Here is an example of what it looks like when the `build-scan-support-tool.jar` is not found in the same directory as the validation scripts.

![image](https://user-images.githubusercontent.com/5797900/198752638-4ecb2c5c-0ba4-4a94-b5c8-a1e17fd0ec33.png)

Additionally, the message "Extracting build scan data, done." has been added to display the status of the Build Scan extraction.

![image](https://user-images.githubusercontent.com/5797900/199110646-bb31b11a-a1b2-4576-ac88-0ffa5f32fcc4.png)

Finally, the Gradle command displayed to the user changes conditionally based on whether `--disable-build-scan-publishing` is used.

**With `--disable-build-scan-publishing`**

![image](https://user-images.githubusercontent.com/5797900/199117228-96512273-d8fc-487a-9a72-559153bd027d.png)

**Without `--disable-build-scan-publishing`**

![image](https://user-images.githubusercontent.com/5797900/199117310-a767d054-ebea-4aa1-b608-892f9408caa2.png)

Closes #170
Closes #184