### PR TITLE
Improve text and guidance when Build Scan publishing is disabled

### DIFF
--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -38,10 +38,6 @@ ge_server=''
 interactive_mode=''
 
 main() {
-  if [[ "$build_scan_publishing_mode" == "off" ]]; then
-    debug "Running experiment with Build Scan publishing disabled."
-  fi
-
   if [ "${interactive_mode}" == "on" ]; then
     wizard_execute
   else

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -341,7 +341,9 @@ $(explain_when_to_rerun_experiment)
 EOF
   else
     IFS='' read -r -d '' text <<EOF
-The ‘Summary’ section below captures the configuration of the experiment.
+The ‘Summary’ section below captures the configuration of the experiment. No
+build scans are available for inspection since publishing was disabled for the
+experiment.
 
 $(explain_build_cache_leverage)
 

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -295,7 +295,9 @@ EOF
 
 explain_measure_build_results() {
   local text
-  IFS='' read -r -d '' text <<EOF
+
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    IFS='' read -r -d '' text <<EOF
 $(print_separator)
 ${HEADER_COLOR}Measure build results${RESTORE}
 
@@ -308,6 +310,21 @@ two builds to assist you in your investigation.
 
 ${USER_ACTION_COLOR}Press <Enter> to measure the build results.${RESTORE}
 EOF
+  else
+    IFS='' read -r -d '' text <<EOF
+$(print_separator)
+${HEADER_COLOR}Measure build results${RESTORE}
+
+Now that the second build has finished successfully, you are ready to measure in
+Gradle Enterprise how well your build leverages Gradle’s local build cache for
+the invoked set of Gradle tasks.
+
+Some of the build scan data will be extracted from the locally stored, intermediate
+build data produced by the two builds to assist you in your investigation.
+
+${USER_ACTION_COLOR}Press <Enter> to measure the build results.${RESTORE}
+EOF
+  fi
   print_wizard_text "${text}"
   wait_for_enter
 }

--- a/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034  # It is common for variables in this auto-generated file to go unused
 # Created by argbash-init v2.10.0
-# ARG_OPTIONAL_BOOLEAN([build-scan-publishing],[],[],[on])
+# ARG_OPTIONAL_BOOLEAN([build-scan-publishing],[x],[],[on])
 # ARG_OPTIONAL_BOOLEAN([fail-if-not-fully-cacheable],[f],[])
 # ARG_HELP([This function is overridden later on.])
 # ARG_VERSION([print_version],[v],[version],[])
@@ -28,6 +28,7 @@ function print_help() {
   print_option_usage -a
   print_option_usage -s
   print_option_usage -e
+  print_option_usage -x
   print_option_usage -f
   print_option_usage -v
   print_option_usage -h

--- a/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034  # It is common for variables in this auto-generated file to go unused
 # Created by argbash-init v2.10.0
-# ARG_OPTIONAL_BOOLEAN([build-scan-publishing],[x],[],[on])
+# ARG_OPTIONAL_BOOLEAN([build-scan-publishing],[],[],[on])
+# ARG_OPTIONAL_BOOLEAN([disable-build-scan-publishing],[x])
 # ARG_OPTIONAL_BOOLEAN([fail-if-not-fully-cacheable],[f],[])
 # ARG_HELP([This function is overridden later on.])
 # ARG_VERSION([print_version],[v],[version],[])

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -271,7 +271,7 @@ print_command_to_repeat_experiment() {
   fi
 
   if [[ "${build_scan_publishing_mode}" == "off" ]]; then
-    cmd+=("--no-build-scan-publishing")
+    cmd+=("-x")
   fi
 
   if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -60,6 +60,11 @@ process_arguments() {
   else
     build_scan_publishing_mode=on
   fi
+  if [ -n "${_arg_disable_build_scan_publishing+x}" ]; then
+    if [[ "${_arg_disable_build_scan_publishing}" == "on" ]]; then
+      build_scan_publishing_mode=off
+    fi
+  fi
 
   if [ -n "${_arg_fail_if_not_fully_cacheable+x}" ]; then
     fail_if_not_fully_cacheable="${_arg_fail_if_not_fully_cacheable}"

--- a/components/scripts/lib/help.sh
+++ b/components/scripts/lib/help.sh
@@ -45,6 +45,9 @@ print_option_usage() {
     -e)
        _print_option_usage "-e, --enable-gradle-enterprise" "Enables Gradle Enterprise on a project not already connected."
        ;;
+    -x)
+       _print_option_usage "-x, --no-build-scan-publishing" "Disables the publication of build scans on the invoked builds."
+       ;;
     -f)
        _print_option_usage "-f, --fail-if-not-fully-cacheable" "Terminates with exit code ${BUILD_NOT_FULLY_CACHEABLE} if the build is not fully cacheable."
        ;;

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -216,7 +216,7 @@ print_build_scans() {
         summary_row "Build scan ${ORDINALS[i]} build:" "${build_scan_urls[i]}"
       fi
     else
-      summary_row "Build scan ${ORDINALS[i]} build:" "Build scan publishing is disabled"
+      summary_row "Build scan ${ORDINALS[i]} build:" "<publication disabled>"
     fi
   done
 }

--- a/components/scripts/lib/wizard.sh
+++ b/components/scripts/lib/wizard.sh
@@ -248,21 +248,22 @@ EOF
 }
 
 explain_prerequisites_api_access() {
-  local text preparation_step documentation_link
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    local text preparation_step documentation_link
 
-  if [ -n "$1" ]; then
-    preparation_step="$1 "
-  else
-    preparation_step=""
-  fi
+    if [ -n "$1" ]; then
+      preparation_step="$1 "
+    else
+      preparation_step=""
+    fi
 
-  if [[ "${BUILD_TOOL}" == "Maven" ]]; then
-    documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md#authenticating-with-gradle-enterprise"
-  else
-    documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-gradle-enterprise"
-  fi
+    if [[ "${BUILD_TOOL}" == "Maven" ]]; then
+      documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md#authenticating-with-gradle-enterprise"
+    else
+      documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-gradle-enterprise"
+    fi
 
-  IFS='' read -r -d '' text <<EOF
+    IFS='' read -r -d '' text <<EOF
 $(print_separator)
 ${HEADER_COLOR}Preparation ${preparation_step}- Ensure Gradle Enterprise API access${RESTORE}
 
@@ -278,8 +279,9 @@ ${documentation_link}
 
 ${USER_ACTION_COLOR}Press <Enter> once you have (optionally) adjusted your access permissions and configured the API credentials on your machine.${RESTORE}
 EOF
-  print_wizard_text "${text}"
-  wait_for_enter
+    print_wizard_text "${text}"
+    wait_for_enter
+  fi
 }
 
 explain_experiment_dir() {


### PR DESCRIPTION
### ✅  remove Running experiment with Build Scan publishing disabled. from the debug mode

```
./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties \
  -b ge \
  -t assemble \
  --no-build-scan-publishing \
  -- debug
```

![image](https://user-images.githubusercontent.com/484822/198998729-dd4b666c-bd98-4eaf-84bc-34dbe38af69e.png)

### ✅  when using -h option for exp3, include it in the list of options (see short/long flag, description, and option ordering):

```
./03-validate-local-build-caching-different-locations.sh --help
```

![image](https://user-images.githubusercontent.com/484822/198998876-87088857-b820-401d-b11d-7d7db2dadd9d.png)

### ✅ use the short form (-x) in the Command Line Invocation section when running in interactive mode (and order as in the example below, i.e. before -f):

```
./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties \
  -b ge \
  -t assemble \
  --no-build-scan-publishing \
  --interactive
```

![image](https://user-images.githubusercontent.com/484822/198999076-42374be6-6697-4bad-87f7-2d0fd6d7008a.png)

### ✅ adjust the text shown in the summary to the following:

```
./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties \
  -b ge \
  -t assemble \
  --no-build-scan-publishing
```

![image](https://user-images.githubusercontent.com/484822/198999350-f5f83995-2230-4fa1-a003-7e1fc0fdba4a.png)

### ✅  Remove the entire section Preparation II. - Ensure Gradle Enterprise API access from the interactive mode when build scan publication is disabled (we can live with the non-perfection of Preparation I. being shown for the prior preparation step)

```
./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties \
  -b ge \
  -t assemble \
  --no-build-scan-publishing \
  --interactive
```

![image](https://user-images.githubusercontent.com/484822/198999506-4aafc72b-2ea6-4d88-b557-579cf49bdbda.png)

### ✅  Replace the text below, shown to the user in the section Measure build during the interactive mode when build scan publication is disabled (leave all other text in that section as it currently is for both cases)...

```
./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties \
  -b ge \
  -t assemble \
  --no-build-scan-publishing \
  --interactive
```

![image](https://user-images.githubusercontent.com/484822/199001075-dd8f9cac-373b-4f3c-8567-20b42841a388.png)

**NOTE**: This PR does not update the message returned when extracting data from the build scan dumps. That will need to be done as part of #179.


### ✅ Add an extra sentence, shown to the user in the section Measure build during the interactive mode when build scan publication is disabled (leave all other text in that section as is for both cases)...

```
./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties \
  -b ge \
  -t assemble \
  --no-build-scan-publishing \
  --interactive
```

![image](https://user-images.githubusercontent.com/484822/198999727-dc06473a-7dc8-4f77-b5bf-97601ea2afb5.png)


Closes #183