### PR TITLE
Rename --no-build-scan-publishing to --disable-build-scan-publishing

### DIFF
--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -78,8 +78,10 @@ wizard_execute() {
   print_bl
   explain_prerequisites_ccud_gradle_plugin "I."
 
-  print_bl
-  explain_prerequisites_api_access "II."
+  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
+    print_bl
+    explain_prerequisites_api_access "II."
+  fi
 
   print_bl
   explain_collect_git_details

--- a/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034  # It is common for variables in this auto-generated file to go unused
 # Created by argbash-init v2.10.0
-# ARG_OPTIONAL_BOOLEAN([build-scan-publishing],[],[],[on])
-# ARG_OPTIONAL_BOOLEAN([disable-build-scan-publishing],[x])
+# ARG_OPTIONAL_BOOLEAN([disable-build-scan-publishing],[x],[])
 # ARG_OPTIONAL_BOOLEAN([fail-if-not-fully-cacheable],[f],[])
 # ARG_HELP([This function is overridden later on.])
 # ARG_VERSION([print_version],[v],[version],[])

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -55,11 +55,7 @@ process_arguments() {
     enable_ge="${_arg_enable_gradle_enterprise}"
   fi
 
-  if [ -n "${_arg_build_scan_publishing+x}" ]; then
-    build_scan_publishing_mode="${_arg_build_scan_publishing}"
-  else
-    build_scan_publishing_mode=on
-  fi
+  build_scan_publishing_mode=on
   if [ -n "${_arg_disable_build_scan_publishing+x}" ]; then
     if [[ "${_arg_disable_build_scan_publishing}" == "on" ]]; then
       build_scan_publishing_mode=off

--- a/components/scripts/lib/wizard.sh
+++ b/components/scripts/lib/wizard.sh
@@ -248,22 +248,21 @@ EOF
 }
 
 explain_prerequisites_api_access() {
-  if [[ "${build_scan_publishing_mode}" == "on" ]]; then
-    local text preparation_step documentation_link
+  local text preparation_step documentation_link
 
-    if [ -n "$1" ]; then
-      preparation_step="$1 "
-    else
-      preparation_step=""
-    fi
+  if [ -n "$1" ]; then
+    preparation_step="$1 "
+  else
+    preparation_step=""
+  fi
 
-    if [[ "${BUILD_TOOL}" == "Maven" ]]; then
-      documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md#authenticating-with-gradle-enterprise"
-    else
-      documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-gradle-enterprise"
-    fi
+  if [[ "${BUILD_TOOL}" == "Maven" ]]; then
+    documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md#authenticating-with-gradle-enterprise"
+  else
+    documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-gradle-enterprise"
+  fi
 
-    IFS='' read -r -d '' text <<EOF
+  IFS='' read -r -d '' text <<EOF
 $(print_separator)
 ${HEADER_COLOR}Preparation ${preparation_step}- Ensure Gradle Enterprise API access${RESTORE}
 
@@ -279,9 +278,8 @@ ${documentation_link}
 
 ${USER_ACTION_COLOR}Press <Enter> once you have (optionally) adjusted your access permissions and configured the API credentials on your machine.${RESTORE}
 EOF
-    print_wizard_text "${text}"
-    wait_for_enter
-  fi
+  print_wizard_text "${text}"
+  wait_for_enter
 }
 
 explain_experiment_dir() {


### PR DESCRIPTION
- Replace --no-build-scan-publishing with --disable-build-scan-publishing
- Eliminate extra blank line in interactive mode when build scan publishing is disabled
