### PR TITLE
Do not require the user to provide a GE server if Build Scan publishing is disabled

### DIFF
--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -84,7 +84,7 @@ validate_required_config() {
     fi
   fi
 
-  if [[ "${enable_ge}" == "on" && "${build_scan_publishing_mode}" == "on" ]]; then
+  if [[ "${enable_ge}" == "on" && ( "${build_scan_publishing_mode}" == "on" || "${BUILD_TOOL}" = "Maven" ) ]]; then
     if [ -z "${ge_server}" ]; then
       _PRINT_HELP=yes die "ERROR: --gradle-enterprise-server is required when using --enable-gradle-enterprise." "${INVALID_INPUT}"
     fi

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -84,7 +84,7 @@ validate_required_config() {
     fi
   fi
 
-  if [[ "${enable_ge}" == "on" ]]; then
+  if [[ "${enable_ge}" == "on" && "${build_scan_publishing_mode}" == "on" ]]; then
     if [ -z "${ge_server}" ]; then
       _PRINT_HELP=yes die "ERROR: --gradle-enterprise-server is required when using --enable-gradle-enterprise." "${INVALID_INPUT}"
     fi

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -24,6 +24,8 @@ invoke_gradle() {
 
   if [ -n "${ge_server}" ]; then
     args+=("-Pcom.gradle.enterprise.build_validation.server=${ge_server}")
+  elif [ "$build_scan_publishing_mode" == "off" ]; then
+    args+=("-Pcom.gradle.enterprise.build_validation.server=https://0.0.0.0")
   fi
 
   args+=(

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -49,10 +49,8 @@ invoke_maven() {
     -Dgradle.scan.captureGoalInputFiles=true
   )
 
-  if [ -n "${ge_server}" ]; then
+  if [ "$build_scan_publishing_mode" == "on" ] && [ -n "${ge_server}" ]; then
     args+=("-Dgradle.enterprise.url=${ge_server}")
-  elif [ "$build_scan_publishing_mode" == "off" ]; then
-    args+=("-Dgradle.enterprise.url=https://0.0.0.0")
   fi
 
   # shellcheck disable=SC2206

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -48,8 +48,11 @@ invoke_maven() {
     -Dcom.gradle.enterprise.build_validation.runId="${RUN_ID}"
     -Dgradle.scan.captureGoalInputFiles=true
   )
+
   if [ -n "${ge_server}" ]; then
     args+=("-Dgradle.enterprise.url=${ge_server}")
+  elif [ "$build_scan_publishing_mode" == "off" ]; then
+    args+=("-Dgradle.enterprise.url=https://0.0.0.0")
   fi
 
   # shellcheck disable=SC2206

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -49,7 +49,7 @@ invoke_maven() {
     -Dgradle.scan.captureGoalInputFiles=true
   )
 
-  if [ "$build_scan_publishing_mode" == "on" ] && [ -n "${ge_server}" ]; then
+  if [ -n "${ge_server}" ]; then
     args+=("-Dgradle.enterprise.url=${ge_server}")
   fi
 


### PR DESCRIPTION
If Build Scan publishing is disabled, then the GE server used doesn't matter.
It isn't captured in the Build Scan dumps, and even if it was, it wouldn't
affect the experiment.

As such, if the user provides `--enable-gradle-enterprise` along with
`--disable-build-scan-publishing`, then no longer require the user to also
provide `--gradle-enterprise-server`.

Unfortunately, the Gradle Enterprise plugin and Maven extension still require a
server to run, so we want to set the server to a dummy value, but only if the
user isn't setting `--gradle-enterprise-server` themselves.
