### PR TITLE
Improve fetch-build-scan-data-cmdline-tool startup perf by setting Picocli sys prop

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/Main.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/Main.java
@@ -7,6 +7,7 @@ import picocli.CommandLine.Help.ColorScheme;
 
 public class Main {
     public static void main(String[] args) {
+        System.setProperty("picocli.disable.closures", "true");  // improves startup time
         ColorScheme colorScheme = CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.AUTO);
         CommandLine cmdLine = new CommandLine(new FetchBuildValidationDataCommand(colorScheme))
             .setExecutionExceptionHandler(new PrintExceptionHandler())


### PR DESCRIPTION
Closure support is only useful when using Picocli with Groovy. Disabling
support for closures reportedly improves startup performance. See
[the Picocli 4.7.0 release notes](https://github.com/remkop/picocli/blob/main/RELEASE-NOTES.md#-picocli-470).
