### PR TITLE
Upgrade Github actions/checkout to v3

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -12,7 +12,7 @@ jobs:
       GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -16,7 +16,7 @@ jobs:
       GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -18,7 +18,7 @@ jobs:
       GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -27,7 +27,7 @@ jobs:
           git_commit_gpgsign: true
           git_config_global: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
Deprecation warnings appear when running actions/checkout@v2, this is fixed when upgrading to actions/checkout@v3
