### PR TITLE
Update some Github actions and remove ::set-output

### DIFF
--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -93,8 +93,8 @@ runs:
         BUILD_SCAN_1=$(grep "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep "second build" ${RECEIPT_FILE} | sed 's/.* //')
         
-        echo "::set-output name=buildScanFirstBuild::$BUILD_SCAN_1"
-        echo "::set-output name=buildScanSecondBuild::$BUILD_SCAN_2"
+        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         echo "::notice title="Experiment 1 - First Build Scan"::$BUILD_SCAN_1"
         echo "::notice title="Experiment 1 - Second Build Scan"::$BUILD_SCAN_2"
       shell: bash

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -93,8 +93,8 @@ runs:
         BUILD_SCAN_1=$(grep "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep "second build" ${RECEIPT_FILE} | sed 's/.* //')
         
-        echo "::set-output name=buildScanFirstBuild::$BUILD_SCAN_1"
-        echo "::set-output name=buildScanSecondBuild::$BUILD_SCAN_2"
+        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         echo "::notice title="Experiment 2 - First Build Scan"::$BUILD_SCAN_1"
         echo "::notice title="Experiment 2 - Second Build Scan"::$BUILD_SCAN_2"
       shell: bash

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -93,8 +93,8 @@ runs:
         BUILD_SCAN_1=$(grep "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep "second build" ${RECEIPT_FILE} | sed 's/.* //')
         
-        echo "::set-output name=buildScanFirstBuild::$BUILD_SCAN_1"
-        echo "::set-output name=buildScanSecondBuild::$BUILD_SCAN_2"
+        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         echo "::notice title="Experiment 3 - First Build Scan"::$BUILD_SCAN_1"
         echo "::notice title="Experiment 3 - Second Build Scan"::$BUILD_SCAN_2"
       shell: bash

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -93,8 +93,8 @@ runs:
         BUILD_SCAN_1=$(grep "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep "second build" ${RECEIPT_FILE} | sed 's/.* //')
       
-        echo "::set-output name=buildScanFirstBuild::$BUILD_SCAN_1"
-        echo "::set-output name=buildScanSecondBuild::$BUILD_SCAN_2"
+        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         echo "::notice title="Experiment 1 - First Build Scan"::$BUILD_SCAN_1"
         echo "::notice title="Experiment 1 - Second Build Scan"::$BUILD_SCAN_2"
       shell: bash

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -93,8 +93,8 @@ runs:
         BUILD_SCAN_1=$(grep "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep "second build" ${RECEIPT_FILE} | sed 's/.* //')
        
-        echo "::set-output name=buildScanFirstBuild::$BUILD_SCAN_1"
-        echo "::set-output name=buildScanSecondBuild::$BUILD_SCAN_2"
+        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         echo "::notice title="Experiment 1 - First Build Scan"::$BUILD_SCAN_1"
         echo "::notice title="Experiment 1 - Second Build Scan"::$BUILD_SCAN_2"
       shell: bash

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/cross-platform-testing.yml
+++ b/.github/workflows/cross-platform-testing.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install -y temurin-${{ matrix.java-version }}-jdk
       - name: Set up JDK ${{ matrix.java-version }}
         if: ${{ runner.os != 'Windows' }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -15,7 +15,7 @@ jobs:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git config --global url."https://unused-username:${TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb4264d3319acaa2bea23d51ef67f80b4f775013
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549
         with:
           gpg_private_key: ${{ secrets.GH_BOT_PGP_PRIVATE_KEY }}
           passphrase: ${{ secrets.GH_BOT_PGP_PASSPHRASE }}


### PR DESCRIPTION
Update some Github actions and remove ::set-output to get rid of deprecation warnings

[Some deprecation warnings are left](https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/3498266802):
- ubuntu-18.04 runner is deprecated 
- macos-10.15 runner is deprecated 