### PR TITLE
Adjust the cross-platform-tests target operating systems 

### DIFF
--- a/.github/workflows/cross-platform-testing.yml
+++ b/.github/workflows/cross-platform-testing.yml
@@ -21,8 +21,6 @@ jobs:
             shell: bash
           - os: ubuntu-22.04
             shell: bash
-          - os: macos-10.15
-            shell: bash
           - os: macos-11
             shell: bash
           - os: macos-12

--- a/.github/workflows/cross-platform-testing.yml
+++ b/.github/workflows/cross-platform-testing.yml
@@ -14,18 +14,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
         java-version: [ '8', '11', '17' ]
         include:
           - os: ubuntu-20.04
             shell: bash
           - os: ubuntu-22.04
-            shell: bash            
+            shell: bash
           - os: macos-10.15
             shell: bash
           - os: macos-11
             shell: bash
+          - os: macos-12
+            shell: bash
           - os: windows-2019
+            shell: wsl-bash
+          - os: windows-2022
             shell: wsl-bash
     defaults:
       run:

--- a/.github/workflows/cross-platform-testing.yml
+++ b/.github/workflows/cross-platform-testing.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019]
         java-version: [ '8', '11', '17' ]
         include:
           - os: ubuntu-20.04
@@ -26,8 +26,6 @@ jobs:
           - os: macos-12
             shell: bash
           - os: windows-2019
-            shell: wsl-bash
-          - os: windows-2022
             shell: wsl-bash
     defaults:
       run:

--- a/.github/workflows/cross-platform-testing.yml
+++ b/.github/workflows/cross-platform-testing.yml
@@ -17,10 +17,10 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-2019]
         java-version: [ '8', '11', '17' ]
         include:
-          - os: ubuntu-18.04
-            shell: bash
           - os: ubuntu-20.04
             shell: bash
+          - os: ubuntu-22.04
+            shell: bash            
           - os: macos-10.15
             shell: bash
           - os: macos-11


### PR DESCRIPTION
Some operating system versions have been deprecated, while others have been added.

Note that we can't test against windows-2022 because WSL v1 is not supported on Windows Server 2022.