### PR TITLE
Append project directory to build directory when running with Build Scan publishing disabled

### DIFF
--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -197,6 +197,9 @@ find_build_scan_dumps() {
 find_build_scan_dump() {
   local build_name="$1"
   local build_dir="${EXP_DIR}/$build_name-build_${project_name}"
+  if [ -n "${project_dir}" ]; then
+    build_dir="$build_dir/$project_dir"
+  fi
   build_scan_dump="$(find "$build_dir" -maxdepth 1 -type f -regex '^.*build-scan-.*-.*-.*-.*\.scan' | sort | tail -n 1)"
   if [ -z "$build_scan_dump" ]; then
     die "ERROR: No Build Scan dump found for the $build_name build"


### PR DESCRIPTION
When both `--build-scan-publishing-disabled` and `--project-dir` are used, the supplied project directory is not currently considered when searching for the Build Scan file. To test these changes, I ran the following command before and after my changes:

```shell
./03-validate-local-build-caching-different-locations.sh \
  -r 'git@github.com:erichaagdev/openapi-generator.git' \
  -b 'upgrade-gradle-7.5.1' \
  -p 'modules/openapi-generator-gradle-plugin' \
  -t assemble \
  -x -e
```

### Before 

![image](https://user-images.githubusercontent.com/5797900/203425223-55065e67-4135-4ee4-9294-fa1173c571ae.png)

### After

![image](https://user-images.githubusercontent.com/5797900/203425178-967ce6b2-ff87-498b-a3cf-f6144a11dd30.png)

Closes #217