### PR TITLE
Add fail if not fully cacheable flag to GH composite workflows

### DIFF
--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -70,7 +70,7 @@ runs:
           ARG_GE_URL="${{ inputs.gradleEnterpriseUrl }}"
         fi
         ARG_GE_ENABLE=""
-        if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
+        if [ "${{ inputs.enableGradleEnterprise }}" == "true" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
 

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -26,6 +26,9 @@ inputs:
   enableGradleEnterprise:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
+  failIfNotFullyCacheable:
+    description: "Fail the build if it is not fully cacheable"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -73,6 +76,10 @@ runs:
         if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
+        ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""
+        if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
+          ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -86,7 +93,8 @@ runs:
           ${ARG_TASKS:+"-t" "$ARG_TASKS"} \
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
-          ${ARG_GE_ENABLE:+"-e"}
+          ${ARG_GE_ENABLE:+"-e"} \
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
   failIfNotFullyCacheable:
-    description: "Fail the build if it is not fully cacheable"
+    description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
 outputs:
   buildScanFirstBuild:

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -73,7 +73,7 @@ runs:
           ARG_GE_URL="${{ inputs.gradleEnterpriseUrl }}"
         fi
         ARG_GE_ENABLE=""
-        if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
+        if [ "${{ inputs.enableGradleEnterprise }}" == "true" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
         ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
   failIfNotFullyCacheable:
-    description: "Fail the build if it is not fully cacheable"
+    description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
 outputs:
   buildScanFirstBuild:

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -73,7 +73,7 @@ runs:
           ARG_GE_URL="${{ inputs.gradleEnterpriseUrl }}"
         fi
         ARG_GE_ENABLE=""
-        if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
+        if [ "${{ inputs.enableGradleEnterprise }}" == "true" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
         ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -26,6 +26,9 @@ inputs:
   enableGradleEnterprise:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
+  failIfNotFullyCacheable:
+    description: "Fail the build if it is not fully cacheable"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -73,6 +76,10 @@ runs:
         if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
+        ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""
+        if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
+          ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -86,7 +93,8 @@ runs:
           ${ARG_TASKS:+"-t" "$ARG_TASKS"} \
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
-          ${ARG_GE_ENABLE:+"-e"}
+          ${ARG_GE_ENABLE:+"-e"} \
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
   failIfNotFullyCacheable:
-    description: "Fail the build if it is not fully cacheable"
+    description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
 outputs:
   buildScanFirstBuild:

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -73,7 +73,7 @@ runs:
           ARG_GE_URL="${{ inputs.gradleEnterpriseUrl }}"
         fi
         ARG_GE_ENABLE=""
-        if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
+        if [ "${{ inputs.enableGradleEnterprise }}" == "true" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
         ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -26,6 +26,9 @@ inputs:
   enableGradleEnterprise:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
+  failIfNotFullyCacheable:
+    description: "Fail the build if it is not fully cacheable"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -73,6 +76,10 @@ runs:
         if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
+        ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""
+        if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
+          ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-maven-build-validation
@@ -86,7 +93,8 @@ runs:
           ${ARG_GOALS:+"-g" "$ARG_GOALS"} \
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
-          ${ARG_GE_ENABLE:+"-e"}
+          ${ARG_GE_ENABLE:+"-e"} \
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
   failIfNotFullyCacheable:
-    description: "Fail the build if it is not fully cacheable"
+    description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
 outputs:
   buildScanFirstBuild:

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -73,7 +73,7 @@ runs:
           ARG_GE_URL="${{ inputs.gradleEnterpriseUrl }}"
         fi
         ARG_GE_ENABLE=""
-        if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
+        if [ "${{ inputs.enableGradleEnterprise }}" == "true" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
         ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -26,6 +26,9 @@ inputs:
   enableGradleEnterprise:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
+  failIfNotFullyCacheable:
+    description: "Fail the build if it is not fully cacheable"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -73,6 +76,10 @@ runs:
         if [ ! -z "${{ inputs.enableGradleEnterprise }}" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
+        ARG_FAIL_IF_NOT_FULLY_CACHEABLE=""
+        if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
+          ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-maven-build-validation
@@ -86,7 +93,8 @@ runs:
           ${ARG_GOALS:+"-g" "$ARG_GOALS"} \
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
-          ${ARG_GE_ENABLE:+"-e"}
+          ${ARG_GE_ENABLE:+"-e"} \
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"


### PR DESCRIPTION
I changed the processing of `enableGradleEnterprise` flag as well to allow true/false configuration.
Previous behavior was to enable the flag as soon as the value was not empty