### PR TITLE
Users understand the cmd line arguments as soon as they have provided all information in interactive mode

### DIFF
--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -82,6 +82,7 @@ wizard_execute() {
   explain_collect_gradle_details
   print_bl
   collect_gradle_details
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   explain_clone_project

--- a/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -89,6 +89,7 @@ wizard_execute() {
   explain_collect_gradle_details
   print_bl
   collect_gradle_details
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   explain_clone_project

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -108,6 +108,7 @@ wizard_execute() {
   explain_collect_gradle_details
   print_bl
   collect_gradle_details
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   explain_first_clone_project

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -293,8 +293,8 @@ explain_first_clone_project(){
 $(print_separator)
 ${HEADER_COLOR}Check out project from Git for first build${RESTORE}
 
-All configuration to run the experiment has been collected. For the first build,
-the Git repository that contains the project to validate will be checked out.
+For the first build, the Git repository that contains the project to validate
+will be checked out.
 
 ${USER_ACTION_COLOR}Press <Enter> to check out the project from Git.${RESTORE}
 EOF

--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -92,6 +92,7 @@ wizard_execute() {
   explain_collect_mapping_file
   print_bl
   collect_mapping_file
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   parse_build_scan_urls
@@ -311,8 +312,8 @@ EOF
   wait_for_enter
 }
 
-#Overrides config.sh#print_command_to_repeat_experiment
-print_command_to_repeat_experiment() {
+#Overrides config.sh#generate_command_to_repeat_experiment
+generate_command_to_repeat_experiment() {
   local cmd
   cmd=("./${SCRIPT_NAME}")
   cmd+=("-1" "${build_scan_urls[0]}")
@@ -322,9 +323,7 @@ print_command_to_repeat_experiment() {
     cmd+=("-m" "${mapping_file}")
   fi
 
-  info "Command Line Invocation"
-  info "-----------------------"
-  info "$(printf '%q ' "${cmd[@]}")"
+  printf '%q ' "${cmd[@]}"
 }
 
 explain_and_print_summary() {

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -115,6 +115,7 @@ wizard_execute() {
   explain_remote_build_cache_url
   print_bl
   collect_remote_build_cache_url
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   explain_clone_project

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -446,8 +446,8 @@ EOF
   wait_for_enter
 }
 
-#Overrides config.sh#print_command_to_repeat_experiment
-print_command_to_repeat_experiment() {
+#Overrides config.sh#generate_command_to_repeat_experiment
+generate_command_to_repeat_experiment() {
   local cmd
   cmd=("./${SCRIPT_NAME}")
 
@@ -495,9 +495,7 @@ print_command_to_repeat_experiment() {
     cmd+=("-e")
   fi
 
-  info "Command Line Invocation"
-  info "-----------------------"
-  info "$(printf '%q ' "${cmd[@]}")"
+  printf '%q ' "${cmd[@]}"
 }
 
 explain_and_print_summary() {

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -231,7 +231,7 @@ print_extra_args() {
   fi
 }
 
-print_command_to_repeat_experiment() {
+generate_command_to_repeat_experiment() {
   local cmd
   cmd=("./${SCRIPT_NAME}" "-r" "${git_repo}")
 
@@ -279,8 +279,6 @@ print_command_to_repeat_experiment() {
     cmd+=("-f")
   fi
 
-  info "Command Line Invocation"
-  info "-----------------------"
-  info "$(printf '%q ' "${cmd[@]}")"
+  printf '%q ' "${cmd[@]}"
 }
 

--- a/components/scripts/lib/wizard.sh
+++ b/components/scripts/lib/wizard.sh
@@ -341,15 +341,26 @@ EOF
   print_wizard_text "${text}"
 }
 
+explain_command_to_repeat_experiment_after_collecting_parameters() {
+  local text
+  IFS='' read -r -d '' text <<EOF
+
+All configuration to run the experiment has been collected. You can repeat
+the experiment in the future by running:
+
+$(generate_command_to_repeat_experiment)
+EOF
+  print_wizard_text "${text}"
+}
+
 explain_clone_project() {
   local text
   IFS='' read -r -d '' text <<EOF
 $(print_separator)
 ${HEADER_COLOR}Check out project from Git${RESTORE}
 
-All configuration to run the experiment has been collected. In the first
-step of the experiment, the Git repository that contains the project to
-validate will be checked out.
+In the first step of the experiment, the Git repository that contains the
+project to validate will be checked out.
 
 ${USER_ACTION_COLOR}Press <Enter> to check out the project from Git.${RESTORE}
 EOF
@@ -374,4 +385,10 @@ changes to your Git repository, you can rerun the experiment and start over
 the cycle of run → measure → improve → run.
 EOF
   echo -n "${text}"
+}
+
+print_command_to_repeat_experiment() {
+    info "Command Line Invocation"
+    info "-----------------------"
+    info "$(generate_command_to_repeat_experiment)"
 }

--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -89,6 +89,7 @@ wizard_execute() {
   explain_collect_maven_details
   print_bl
   collect_maven_details
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   explain_clone_project

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -89,6 +89,7 @@ wizard_execute() {
   explain_collect_maven_details
   print_bl
   collect_maven_details
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   explain_first_clone_project

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -229,8 +229,8 @@ explain_first_clone_project(){
 $(print_separator)
 ${HEADER_COLOR}Check out project from Git for first build${RESTORE}
 
-All configuration to run the experiment has been collected. For the first build,
-the Git repository that contains the project to validate will be checked out.
+For the first build, the Git repository that contains the project to validate
+will be checked out.
 
 ${USER_ACTION_COLOR}Press <Enter> to check out the project from Git.${RESTORE}
 EOF

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -90,6 +90,7 @@ wizard_execute() {
   explain_collect_mapping_file
   print_bl
   collect_mapping_file
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   parse_build_scan_urls
@@ -309,8 +310,8 @@ EOF
   wait_for_enter
 }
 
-#Overrides config.sh#print_command_to_repeat_experiment
-print_command_to_repeat_experiment() {
+#Overrides config.sh#generate_command_to_repeat_experiment
+generate_command_to_repeat_experiment() {
   local cmd
   cmd=("./${SCRIPT_NAME}")
   cmd+=("-1" "${build_scan_urls[0]}")
@@ -320,9 +321,7 @@ print_command_to_repeat_experiment() {
     cmd+=("-m" "${mapping_file}")
   fi
 
-  info "Command Line Invocation"
-  info "-----------------------"
-  info "$(printf '%q ' "${cmd[@]}")"
+  printf '%q ' "${cmd[@]}"
 }
 
 explain_and_print_summary() {

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -451,8 +451,8 @@ EOF
   wait_for_enter
 }
 
-#Overrides config.sh#print_command_to_repeat_experiment
-print_command_to_repeat_experiment() {
+#Overrides config.sh#generate_command_to_repeat_experiment
+generate_command_to_repeat_experiment() {
   local cmd
   cmd=("./${SCRIPT_NAME}")
 
@@ -500,9 +500,7 @@ print_command_to_repeat_experiment() {
     cmd+=("-e")
   fi
 
-  info "Command Line Invocation"
-  info "-----------------------"
-  info "$(printf '%q ' "${cmd[@]}")"
+  printf '%q ' "${cmd[@]}"
 }
 
 explain_and_print_summary() {

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -114,6 +114,7 @@ wizard_execute() {
   explain_remote_build_cache_url
   print_bl
   collect_remote_build_cache_url
+  explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
   explain_clone_project


### PR DESCRIPTION
If the experiment needs to be interrupted for some reason, it's rather annoying
to have to re-enter all of the settings when re-running the experiment. We show
the command to repeat the experiment at the end of the summary, but that's only
helpful if the script completes normally.

This commit updates interactive mode to also show the command to repeat the
experiment immediately after all of the configuration options have been
collected, but before executing any of the builds.
