### PR TITLE
Add missing `-f` on command to repeat experiment for several experiments

### DIFF
--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -323,6 +323,10 @@ generate_command_to_repeat_experiment() {
     cmd+=("-m" "${mapping_file}")
   fi
 
+  if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
+    cmd+=("-f")
+  fi
+
   printf '%q ' "${cmd[@]}"
 }
 

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -495,6 +495,10 @@ generate_command_to_repeat_experiment() {
     cmd+=("-e")
   fi
 
+  if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
+    cmd+=("-f")
+  fi
+
   printf '%q ' "${cmd[@]}"
 }
 

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -321,6 +321,10 @@ generate_command_to_repeat_experiment() {
     cmd+=("-m" "${mapping_file}")
   fi
 
+  if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
+    cmd+=("-f")
+  fi
+
   printf '%q ' "${cmd[@]}"
 }
 

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -500,6 +500,10 @@ generate_command_to_repeat_experiment() {
     cmd+=("-e")
   fi
 
+  if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
+    cmd+=("-f")
+  fi
+
   printf '%q ' "${cmd[@]}"
 }
 

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
+- [FIX] Several experiments missing `-f` in their command to repeat experiment
 - [NEW] Add `-x` command line option to control if build scan should be published


### PR DESCRIPTION
## Testing

### `exp3-maven`

```shell
./03-validate-remote-build-caching-ci-ci.sh \
  -1 'https://ge.solutions-team.gradle.com/s/ed6a3h7m3swpa' \
  -2 'https://ge.solutions-team.gradle.com/s/eq5u5tbq6xdyo' \
  --fail-if-not-fully-cacheable \
  --interactive
```

![image](https://user-images.githubusercontent.com/5797900/207077264-17296dd7-7a6a-441d-bd01-27adf5f1e9d8.png)

![image](https://user-images.githubusercontent.com/5797900/207077326-c97c3e7a-295a-46a6-80cc-47c8fb78806b.png)

### `exp4-maven`

```shell
./04-validate-remote-build-caching-ci-local.sh \
  -1 'https://ge.solutions-team.gradle.com/s/ed6a3h7m3swpa' \
  --args '-DskipTests' \
  --remote-build-cache-url 'https://ge.solutions-team.gradle.com/cache' \
  --fail-if-not-fully-cacheable \
  --interactive
```

![image](https://user-images.githubusercontent.com/5797900/207077907-33ccd3b4-22d8-42b9-84e1-8cfc58973dc3.png)

![image](https://user-images.githubusercontent.com/5797900/207078263-951ad85b-06bd-45a0-afc8-21b8dcb098fe.png)

### `exp4-gradle`

```shell
./04-validate-remote-build-caching-ci-ci.sh \
  -1 https://ge.solutions-team.gradle.com/s/k2gzrbklej2eq \
  -2 https://ge.solutions-team.gradle.com/s/2dn2py4gxhm7y \
  --fail-if-not-fully-cacheable \
  --interactive
```

![image](https://user-images.githubusercontent.com/5797900/207075767-00727218-e1d0-49e5-9d8d-972b14a1e328.png)

![image](https://user-images.githubusercontent.com/5797900/207075840-6080eb6a-f8a6-4fa2-8be4-d6ce47adef65.png)

### `exp5-gradle`

```shell
./05-validate-remote-build-caching-ci-local.sh \
  -1 https://ge.solutions-team.gradle.com/s/s7p73cvpbjua4 \
  -u https://ge.solutions-team.gradle.com/cache \
  --fail-if-not-fully-cacheable \
  --interactive
```

![image](https://user-images.githubusercontent.com/5797900/207076313-0fb907c8-c6ee-431b-971a-7e0754816025.png)

![image](https://user-images.githubusercontent.com/5797900/207076427-73d6d0cf-196b-434d-a616-0f48e781b42e.png)

Closes #231