### PR TITLE
Ensure correctness of `storeEnabled` for local caching in Maven experiments

### DIFF
--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -143,6 +143,7 @@ execute_build() {
   #shellcheck disable=SC2086  # we actually want ${tasks} to expand because it may have more than one maven goal
   invoke_maven \
      -Dgradle.cache.local.enabled=true \
+     -Dgradle.cache.local.storeEnabled=true \
      -Dgradle.cache.remote.enabled=false \
      -Dgradle.cache.local.directory="${BUILD_CACHE_DIR}" \
      clean ${tasks}

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -147,6 +147,7 @@ execute_build() {
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
   invoke_maven \
      -Dgradle.cache.local.enabled=true \
+     -Dgradle.cache.local.storeEnabled=true \
      -Dgradle.cache.remote.enabled=false \
      -Dgradle.cache.local.directory="${BUILD_CACHE_DIR}" \
      clean ${tasks}

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
+- [FIX] Maven experiments ensure correctness of `storeEnabled` for local caching
 - [NEW] Add `-x` command line option to control if build scan should be published


### PR DESCRIPTION
I was able to recreate this issue as seen in the following [Build Scan](https://ge.solutions-team.gradle.com/s/nof5ijxxb53ju/performance/build-cache#local-cache-store).

Using the exact same code base, I reran the experiments and saw local cache pushing was enabled as can be seen in the following Build Scans: 

- [exp1-maven](https://ge.solutions-team.gradle.com/s/owhf3ct5garna/performance/build-cache#local-cache-store)
- [exp2-maven](https://ge.solutions-team.gradle.com/s/b3zoslui6sl4y/performance/build-cache#local-cache-store)

You can also see the builds benefited from the local cache as expected.

Closes #227