### PR TITLE
Only read build cache metrics when Build Scan publishing is disabled

### DIFF
--- a/components/scripts/lib/build-scan-dump.sh
+++ b/components/scripts/lib/build-scan-dump.sh
@@ -37,6 +37,6 @@ read_build_scan_dumps() {
   local build_scan_csv
   echo -n "Extracting build scan data"
   build_scan_csv="$(invoke_java "$BUILD_SCAN_SUPPORT_TOOL_JAR" extract "${build_scan_dumps[0]}"  "${build_scan_dumps[1]}")"
-  parse_build_scan_csv "$build_scan_csv"
+  parse_build_scan_csv "$build_scan_csv" "build_cache_metrics_only"
   echo ", done."
 }

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -43,35 +43,35 @@ parse_build_scan_csv() {
 
   # shellcheck disable=SC2034 # not all scripts use all of the fetched data
   while IFS=, read -r field_1 field_2 field_3 field_4 field_5 field_6 field_7 field_8 field_9 field_10 field_11 field_12 field_13 field_14 field_15 field_16 field_17 field_18 field_19; do
-     if [[ "$header_row_read" == "false" ]]; then
-         header_row_read=true
-         continue;
-     fi
+    if [[ "$header_row_read" == "false" ]]; then
+      header_row_read=true
+      continue;
+    fi
 
-  if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
-       project_names[idx]="$field_1"
-       base_urls[idx]="$field_2"
-       build_scan_urls[idx]="$field_3"
-       build_scan_ids[idx]="$field_4"
-       git_repos[idx]="$field_5"
-       git_branches[idx]="$field_6"
-       git_commit_ids[idx]="$field_7"
-       requested_tasks[idx]="$(remove_clean_task "${field_8}")"
-       build_outcomes[idx]="$field_9"
-       remote_build_cache_urls[idx]="${field_10}"
-       remote_build_cache_shards[idx]="${field_11}"
-     fi
+    if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
+      project_names[idx]="$field_1"
+      base_urls[idx]="$field_2"
+      build_scan_urls[idx]="$field_3"
+      build_scan_ids[idx]="$field_4"
+      git_repos[idx]="$field_5"
+      git_branches[idx]="$field_6"
+      git_commit_ids[idx]="$field_7"
+      requested_tasks[idx]="$(remove_clean_task "${field_8}")"
+      build_outcomes[idx]="$field_9"
+      remote_build_cache_urls[idx]="${field_10}"
+      remote_build_cache_shards[idx]="${field_11}"
+    fi
 
-     # Build caching performance metrics
-     avoided_up_to_date_num_tasks[idx]="${field_12}"
-     avoided_up_to_date_avoidance_savings[idx]="${field_13}"
-     avoided_from_cache_num_tasks[idx]="${field_14}"
-     avoided_from_cache_avoidance_savings[idx]="${field_15}"
-     executed_cacheable_num_tasks[idx]="${field_16}"
-     executed_cacheable_duration[idx]="${field_17}"
-     executed_not_cacheable_num_tasks[idx]="${field_18}"
-     executed_not_cacheable_duration[idx]="${field_19}"
+    # Build caching performance metrics
+    avoided_up_to_date_num_tasks[idx]="${field_12}"
+    avoided_up_to_date_avoidance_savings[idx]="${field_13}"
+    avoided_from_cache_num_tasks[idx]="${field_14}"
+    avoided_from_cache_avoidance_savings[idx]="${field_15}"
+    executed_cacheable_num_tasks[idx]="${field_16}"
+    executed_cacheable_duration[idx]="${field_17}"
+    executed_not_cacheable_num_tasks[idx]="${field_18}"
+    executed_not_cacheable_duration[idx]="${field_19}"
 
-     ((idx++))
-  done <<< "${build_scan_csv}"
+    ((idx++))
+    done <<< "${build_scan_csv}"
 }

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -48,6 +48,8 @@ parse_build_scan_csv() {
       continue;
     fi
 
+    project_names[idx]="$field_1"
+
     if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
       base_urls[idx]="$field_2"
       build_scan_urls[idx]="$field_3"
@@ -60,8 +62,6 @@ parse_build_scan_csv() {
       remote_build_cache_urls[idx]="${field_10}"
       remote_build_cache_shards[idx]="${field_11}"
     fi
-
-    project_names[idx]="$field_1"
 
     # Build caching performance metrics
     avoided_up_to_date_num_tasks[idx]="${field_12}"

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -49,7 +49,6 @@ parse_build_scan_csv() {
     fi
 
     if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
-      project_names[idx]="$field_1"
       base_urls[idx]="$field_2"
       build_scan_urls[idx]="$field_3"
       build_scan_ids[idx]="$field_4"
@@ -61,6 +60,8 @@ parse_build_scan_csv() {
       remote_build_cache_urls[idx]="${field_10}"
       remote_build_cache_shards[idx]="${field_11}"
     fi
+
+    project_names[idx]="$field_1"
 
     # Build caching performance metrics
     avoided_up_to_date_num_tasks[idx]="${field_12}"


### PR DESCRIPTION
This resolves an issue when running with the latest scripts version and `build-scan-support-tool-0.0.4.jar` in which the Git details would not be displayed:

![image](https://user-images.githubusercontent.com/5797900/207718855-4dd4a64e-0214-4681-86e4-bf142bcd1630.png)

Previously, the build validation scripts read Git details from the CSV returned by the `build-scan-support-tool.jar`. The tool read this information from the custom values added by the CCUD plugin on the Build Scan. As of `0.0.4` the tool does not read custom values and the Git details are returned to the build validation scripts as `null`.

This _is_ different than how the `fetch-build-scan-data-cmdline-tool` works. It does read Git details from custom values and they are passed back to the build validation scripts in the CSV.

However, Git details are _not_ sourced from the CSV for `exp2-gradle`, `exp3-gradle`, `exp1-maven`, and `exp2-maven` and instead they [are sourced from the environment](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/4e5f4809ca50033339f1c538c70d7da1c8b59c12/components/scripts/lib/build_scan.sh#L18) so this difference is not really relevant.

That being said, removing Git details from the `build-scan-support-tool-0.0.4.jar` did expose an issue in how the build validation scripts process between Build Scan publishing enabled/disabled. That is we pass the parameter `"build_cache_metrics_only"` to `parse_build_scan_csv` when Build Scan publishing is enabled, but not when it is disabled. This caused the Git details from the environment to be overwritten by whatever was returned by the `build-scan-support-tool.jar` which is incorrect for these experiments.

This exposed another minor problem in that the project name when Build Scan publishing is enabled is sourced from the `build-scans.csv` file, but that file does not exist when Build Scan publishing is disabled. This was causing the project name to not display when using `"build_cache_metrics_only"`.

![image](https://user-images.githubusercontent.com/5797900/207726628-fe7ac7dc-a2e3-4996-9778-8f3194ab9d38.png)

To address this, I'm sourcing the project name from the CSV returned by the `build-scan-support-tool.jar` when Build Scan publishing is disabled. This is exactly what we were doing before this change. 

### Testing

To test these changes, I ran all of the following experiments and verified all had "Project", "Git repo", "Git branch", and "Git commit id" populated.

#### Gradle

```shell
./01-validate-incremental-building.sh -r git@github.com:etiennestuder/java-ordered-properties.git -t build -s https://ge.solutions-team.gradle.com
./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git -t build -p sample-projects/gradle/7.x/ge
./02-validate-local-build-caching-same-location.sh -r git@github.com:etiennestuder/java-ordered-properties.git -t build -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-same-location.sh -x -r git@github.com:etiennestuder/java-ordered-properties.git -t build
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -t build -p sample-projects/gradle/7.x/ge
./02-validate-local-build-caching-same-location.sh -x -r git@github.com:gradle/ge-solutions.git -t build -p sample-projects/gradle/7.x/ge
./03-validate-local-build-caching-different-locations.sh -r git@github.com:etiennestuder/java-ordered-properties.git -t build -s https://ge.solutions-team.gradle.com
./03-validate-local-build-caching-different-locations.sh -x -r git@github.com:etiennestuder/java-ordered-properties.git -t build
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -t build -p sample-projects/gradle/7.x/ge
./03-validate-local-build-caching-different-locations.sh -x -r git@github.com:gradle/ge-solutions.git -t build -p sample-projects/gradle/7.x/ge
./04-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/k2gzrbklej2eq -2 https://ge.solutions-team.gradle.com/s/2dn2py4gxhm7y
./05-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/s7p73cvpbjua4 -u https://ge.solutions-team.gradle.com/cache
```

#### Maven

```shell
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/gradle-enterprise-build-config-samples.git -g install -p common-gradle-enterprise-maven-configuration -s https://ge.solutions-team.gradle.com
./01-validate-local-build-caching-same-location.sh -x -r git@github.com:gradle/gradle-enterprise-build-config-samples.git -g install -p common-gradle-enterprise-maven-configuration
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -g install -p sample-projects/maven/3.8.x/ge
./01-validate-local-build-caching-same-location.sh -x -r git@github.com:gradle/ge-solutions.git -g install -p sample-projects/maven/3.8.x/ge
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/gradle-enterprise-build-config-samples.git -g install -p common-gradle-enterprise-maven-configuration -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-different-locations.sh -x -r git@github.com:gradle/gradle-enterprise-build-config-samples.git -g install -p common-gradle-enterprise-maven-configuration
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -g install -p sample-projects/maven/3.8.x/ge
./02-validate-local-build-caching-different-locations.sh -x -r git@github.com:gradle/ge-solutions.git -g install -p sample-projects/maven/3.8.x/ge
./03-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/ed6a3h7m3swpa -2 https://ge.solutions-team.gradle.com/s/eq5u5tbq6xdyo
./04-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/ed6a3h7m3swpa --args '-DskipTests' --remote-build-cache-url https://ge.solutions-team.gradle.com/cache
```