### PR TITLE
Remove special Maven check when `-e` is used

### DIFF
--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -84,10 +84,8 @@ validate_required_config() {
     fi
   fi
 
-  if [[ "${enable_ge}" == "on" && "${build_scan_publishing_mode}" == "on" ]]; then
-    if [ -z "${ge_server}" ]; then
-      _PRINT_HELP=yes die "ERROR: --gradle-enterprise-server is required when using --enable-gradle-enterprise." "${INVALID_INPUT}"
-    fi
+  if [[ "${enable_ge}" == "on" && -z "${ge_server}" && "${build_scan_publishing_mode}" == "on" ]]; then
+    _PRINT_HELP=yes die "ERROR: --gradle-enterprise-server is required when using --enable-gradle-enterprise." "${INVALID_INPUT}"
   fi
 }
 

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -84,7 +84,7 @@ validate_required_config() {
     fi
   fi
 
-  if [[ "${enable_ge}" == "on" && ( "${build_scan_publishing_mode}" == "on" || "${BUILD_TOOL}" = "Maven" ) ]]; then
+  if [[ "${enable_ge}" == "on" && "${build_scan_publishing_mode}" == "on" ]]; then
     if [ -z "${ge_server}" ]; then
       _PRINT_HELP=yes die "ERROR: --gradle-enterprise-server is required when using --enable-gradle-enterprise." "${INVALID_INPUT}"
     fi


### PR DESCRIPTION
## Tests

### Maven

```
./02-validate-local-build-caching-different-locations.sh \
  -r https://github.com/apache/maven \
  -g package -x -e
```

![image](https://user-images.githubusercontent.com/5797900/208728574-7b3914ee-b4c0-4dd2-b92c-60e290735955.png)

---

```
./02-validate-local-build-caching-different-locations.sh \
  -r https://github.com/apache/maven \
  -g package -e
```

![image](https://user-images.githubusercontent.com/5797900/208731810-5962135d-b370-4bc2-9345-6e7679bfcf8d.png)

---

```
./02-validate-local-build-caching-different-locations.sh \
  -r https://github.com/apache/maven \
  -g package -e -s https://ge.solutions-team.gradle.com
```

![image](https://user-images.githubusercontent.com/5797900/208732197-9e117917-c7f1-46ac-acf7-1cdb99688c9e.png)

### Gradle

```
./03-validate-local-build-caching-different-locations.sh \
  -r https://github.com/etiennestuder/java-ordered-properties \
  -t assemble -x -e
```

![image](https://user-images.githubusercontent.com/5797900/208732404-f0c81ab2-156b-4627-992d-75e06d54081f.png)

---

```
./03-validate-local-build-caching-different-locations.sh \
  -r https://github.com/etiennestuder/java-ordered-properties \
  -t assemble -e
```

![image](https://user-images.githubusercontent.com/5797900/208732462-0cb3f71a-b217-4700-a3cd-988c68d00523.png)

---

```
./03-validate-local-build-caching-different-locations.sh \
  -r https://github.com/etiennestuder/java-ordered-properties \
  -t assemble -e -s https://ge.solutions-team.gradle.com
```

![image](https://user-images.githubusercontent.com/5797900/208732557-3ae363a3-53d9-4278-ae1e-37f6e42fcee8.png)