### PR TITLE
Fix initialization script does not exist

### DIFF
--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -19,6 +19,7 @@ readonly SCRIPT_NAME
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo .)")"; pwd)"
 readonly SCRIPT_DIR
 readonly LIB_DIR="${SCRIPT_DIR}/lib"
+readonly INIT_SCRIPTS_DIR="${LIB_DIR}/gradle-init-scripts"
 
 # Include and parse the command line arguments
 # shellcheck source=lib/01-cli-parser.sh

--- a/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -19,6 +19,7 @@ readonly SCRIPT_NAME
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo .)")"; pwd)"
 readonly SCRIPT_DIR
 readonly LIB_DIR="${SCRIPT_DIR}/lib"
+readonly INIT_SCRIPTS_DIR="${LIB_DIR}/gradle-init-scripts"
 
 # Include and parse the command line arguments
 # shellcheck source=lib/02-cli-parser.sh
@@ -138,15 +139,12 @@ execute_second_build() {
 }
 
 execute_build() {
-  local init_scripts_dir
-  init_scripts_dir="$(init_scripts_path)"
-
   print_gradle_command
 
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
   invoke_gradle \
      --build-cache \
-     --init-script "${init_scripts_dir}/configure-local-build-caching.gradle" \
+     --init-script "${INIT_SCRIPTS_DIR}/configure-local-build-caching.gradle" \
      clean ${tasks}
 }
 

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -19,6 +19,7 @@ readonly SCRIPT_NAME
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo .)")"; pwd)"
 readonly SCRIPT_DIR
 readonly LIB_DIR="${SCRIPT_DIR}/lib"
+readonly INIT_SCRIPTS_DIR="${LIB_DIR}/gradle-init-scripts"
 
 # Include and parse the command line arguments
 # shellcheck source=lib/03-cli-parser.sh
@@ -143,15 +144,12 @@ execute_second_build() {
 }
 
 execute_build() {
-  local init_scripts_dir
-  init_scripts_dir="$(init_scripts_path)"
-
   print_gradle_command
 
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
   invoke_gradle \
      --build-cache \
-     --init-script "${init_scripts_dir}/configure-local-build-caching.gradle" \
+     --init-script "${INIT_SCRIPTS_DIR}/configure-local-build-caching.gradle" \
      clean ${tasks}
 }
 

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -19,6 +19,7 @@ readonly SCRIPT_NAME
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo .)")"; pwd)"
 readonly SCRIPT_DIR
 readonly LIB_DIR="${SCRIPT_DIR}/lib"
+readonly INIT_SCRIPTS_DIR="${LIB_DIR}/gradle-init-scripts"
 
 # Include and parse the command line arguments
 # shellcheck source=lib/05-cli-parser.sh
@@ -192,11 +193,8 @@ validate_build_config() {
 }
 
 execute_build() {
-  local init_scripts_dir
-  init_scripts_dir="$(init_scripts_path)"
-
   local args
-  args=(--build-cache --init-script "${init_scripts_dir}/configure-remote-build-caching.gradle")
+  args=(--build-cache --init-script "${INIT_SCRIPTS_DIR}/configure-remote-build-caching.gradle")
   if [ -n "${remote_build_cache_url}" ]; then
     args+=("-Pcom.gradle.enterprise.build_validation.remoteBuildCacheUrl=${remote_build_cache_url}")
   fi

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-init_scripts_path() {
-  # The gradle --init-script flag only accepts a relative directory path. ¯\_(ツ)_/¯
-  lib_dir_rel="$(relative_lib_path)"
-  echo "${lib_dir_rel}/gradle-init-scripts"
-}
-
 invoke_gradle() {
   local args
   args=()
@@ -16,15 +10,12 @@ invoke_gradle() {
     cd "${project_dir}" > /dev/null 2>&1 || die "ERROR: The subdirectory ${project_dir} (set with --project-dir) does not exist in ${project_name}." "${INVALID_INPUT}"
   fi
 
-  local init_scripts_dir
-  init_scripts_dir="$(init_scripts_path)"
-
   if [ "$enable_ge" == "on" ]; then
-    args+=(--init-script "${init_scripts_dir}/enable-gradle-enterprise.gradle")
+    args+=(--init-script "${INIT_SCRIPTS_DIR}/enable-gradle-enterprise.gradle")
   fi
 
-  args+=(--init-script "${init_scripts_dir}/configure-gradle-enterprise.gradle")
-  args+=(--init-script "${init_scripts_dir}/capture-published-build-scan.gradle")
+  args+=(--init-script "${INIT_SCRIPTS_DIR}/configure-gradle-enterprise.gradle")
+  args+=(--init-script "${INIT_SCRIPTS_DIR}/capture-published-build-scan.gradle")
 
   if [ -n "${ge_server}" ]; then
     args+=("-Pcom.gradle.enterprise.build_validation.server=${ge_server}")

--- a/components/scripts/lib/paths.sh
+++ b/components/scripts/lib/paths.sh
@@ -45,22 +45,3 @@ relative_path() {
 
     printf '%s\n' "$result"
 }
-
-relative_lib_path() {
-  local original_dir
-  if [ -n "${project_dir}" ]; then
-    original_dir="$(pwd)"
-    cd "${project_dir}" > /dev/null 2>&1 || die "ERROR: The subdirectory ${project_dir} (set with --project-dir) does not exist in ${project_name}." "${INVALID_INPUT}"
-  fi
-
-  local lib_dir_rel
-  lib_dir_rel=$(relative_path "$( pwd )" "${LIB_DIR}")
-
-  if [ -n "${project_dir}" ]; then
-    # shellcheck disable=SC2164 # We are just navigating back to the original directory
-    cd "${original_dir}"
-  fi
-
-  echo "${lib_dir_rel}"
-}
-


### PR DESCRIPTION
### Tests

Ran experiments 1, 2, & 3 for Gradle 5.x, 6.x, 7.x, & androidx and verified all succeeded:

```
./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/5.x/ge -t 'build'
./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/6.x/ge -t 'build'
./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/7.x/ge -t 'build'
./01-validate-incremental-building.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer zipTestConfigsWithApks test' -a '-x ktlint' -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/5.x/ge -t 'build'
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/6.x/ge -t 'build'
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/7.x/ge -t 'build'
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer zipTestConfigsWithApks test' -a '-x ktlint' -s https://ge.solutions-team.gradle.com
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/5.x/ge -t 'build'
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/6.x/ge -t 'build'
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/7.x/ge -t 'build'
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer zipTestConfigsWithApks test' -a '-x ktlint' -s https://ge.solutions-team.gradle.com
```