### PR TITLE
Adopt Foojay Toolchains and Kotlin DSL plugins in build logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The build validation scripts are available as pre-built, executable Bash scripts
 
 ## Build from source
 
-You can also assemble the build validation scripts from source by running `./gradlew build` from the root folder of this repository. If you run the build on a M1-Apple machine, the build requires Java 8 to already be installed. This requirement is due to Gradle currently not being able to download Java 8 via its Toolchain feature.
+You can also assemble the build validation scripts from source by running `./gradlew build` from the root folder of this repository.
 
 Once the build has finished successfully, you can find two .zip files in the build/distributions folder: one .zip file containing the build validation scripts for Gradle and one .zip file containing the build validation scripts for Maven.
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.8.10"
+    `kotlin-dsl`
 }
 
 kotlin {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 kotlin {
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
+
+        // Azul has been chosen due to its wide range of supported platforms for
+        // Java 8, including arm64 for macOS.
+        // See: https://foojay.io/almanac/jdk-8
         vendor.set(JvmVendorSpec.AZUL)
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 kotlin {
     jvmToolchain {
-        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(8))
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 kotlin {
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
+        vendor.set(JvmVendorSpec.AZUL)
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
 kotlin {
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
-
-        // Azul has been chosen due to its wide range of supported platforms for
-        // Java 8, including arm64 for macOS.
-        // See: https://foojay.io/almanac/jdk-8
         vendor.set(JvmVendorSpec.AZUL)
     }
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+}
+
+rootProject.name = "buildSrc"

--- a/buildSrc/src/main/kotlin/ApplyArgbash.kt
+++ b/buildSrc/src/main/kotlin/ApplyArgbash.kt
@@ -42,15 +42,15 @@ abstract class ApplyArgbash @Inject constructor(
     fun applyArgbash() {
         val argbash = argbashHome.get().file("bin/argbash").asFile
         scriptTemplates.get().visit {
-            if(!it.isDirectory) {
-                val relPath = it.relativePath.parent.pathString
-                val basename = it.file.nameWithoutExtension
-                val outputFile = outputDir.get().file("${relPath}/${basename}.sh").asFile
+            if(!isDirectory) {
+                val relPath = relativePath.parent.pathString
+                val basename = file.nameWithoutExtension
+                val outputFile = outputDir.get().file("$relPath/$basename.sh").asFile
                 outputFile.parentFile.mkdirs()
 
-                logger.info("Applying argbash to $it.file")
-                execOperations.exec { execSpec ->
-                    execSpec.commandLine(argbash, it.file, "-o", outputFile)
+                logger.info("Applying argbash to $file")
+                execOperations.exec {
+                    commandLine(argbash, file, "-o", outputFile)
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/CreateGitTag.kt
+++ b/buildSrc/src/main/kotlin/CreateGitTag.kt
@@ -26,21 +26,21 @@ abstract class CreateGitTag @Inject constructor(
     @TaskAction
     fun applyArgbash() {
         logger.info("Tagging HEAD as ${tagName.get()}")
-        execOperations.exec { execSpec ->
+        execOperations.exec {
             val args = mutableListOf("git", "tag")
             if (overwriteExisting.get()) {
                 args.add("-f")
             }
             args.add(tagName.get())
-            execSpec.commandLine(args)
+            commandLine(args)
         }
-        execOperations.exec { execSpec ->
+        execOperations.exec {
             val args = mutableListOf("git", "push", "origin")
             if (overwriteExisting.get()) {
                 args.add("-f")
             }
             args.add("--tags")
-            execSpec.commandLine(args)
+            commandLine(args)
         }
     }
 }

--- a/components/capture-build-scan-url-maven-extension/build.gradle.kts
+++ b/components/capture-build-scan-url-maven-extension/build.gradle.kts
@@ -17,6 +17,7 @@ description = "Maven extension to capture the build scan URL"
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
+        vendor.set(JvmVendorSpec.AZUL)
     }
 }
 

--- a/components/fetch-build-scan-data-cmdline-tool/build.gradle.kts
+++ b/components/fetch-build-scan-data-cmdline-tool/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(8))
+        vendor.set(JvmVendorSpec.AZUL)
     }
 }
 


### PR DESCRIPTION
## ❄️ Winter Update PR Navigator ❄️

1. #261
2. #262
3. #263
4. #264
5. ⛄ #265
6. #266
7. #267
8. #272
9. #274
10. #283

⛄ = you are here

## Summary

This PR updates `buildSrc` to auto-provision the required JVM toolchains using the [Foojay Toolchains Plugin](https://github.com/gradle/foojay-toolchains) and sets the distribution vendor to `AZUL`. 

Additionally, I updated `buildSrc` to use the `kotlin-dsl` plugin. See [this comment for context](https://github.com/gradle/gradle-enterprise-build-validation-scripts/pull/260#issuecomment-1366705438)

Closes #254