### PR TITLE
Fix createReleaseTag ordering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,6 +262,8 @@ githubRelease {
 }
 
 val createReleaseTag by tasks.registering(CreateGitTag::class) {
+    // Ensure tag is created only after a successful build
+    mustRunAfter("build")
     tagName.set(gitReleaseTag())
     overwriteExisting.set(isDevelopmentRelease)
 }


### PR DESCRIPTION
This should ensure `createReleaseTag` is executed after `build` whenever `build githubRelease` is requested.