### PR TITLE
Display serialization factor in summary of all experiments

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/api/client/GradleEnterpriseApiClient.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/api/client/GradleEnterpriseApiClient.java
@@ -118,7 +118,8 @@ public class GradleEnterpriseApiClient {
                     remoteBuildCacheUrlFrom(buildCachePerformance),
                     summarizeTaskExecutions(buildCachePerformance),
                     toDuration(buildCachePerformance.getEffectiveTaskExecutionTime()),
-                    BigDecimal.valueOf(buildCachePerformance.getSerializationFactor()));
+                    BigDecimal.valueOf(buildCachePerformance.getSerializationFactor())
+                );
             }
             if (build.getBuildToolType().equalsIgnoreCase("maven")) {
                 MavenAttributes attributes = apiClient.getMavenAttributes(buildScanId, null);
@@ -136,7 +137,8 @@ public class GradleEnterpriseApiClient {
                     remoteBuildCacheUrlFrom(buildCachePerformance),
                     summarizeTaskExecutions(buildCachePerformance),
                     toDuration(buildCachePerformance.getEffectiveProjectExecutionTime()),
-                    BigDecimal.valueOf(buildCachePerformance.getSerializationFactor()));
+                    BigDecimal.valueOf(buildCachePerformance.getSerializationFactor())
+                );
             }
             throw new UnknownBuildAgentException(baseUrl, buildScanId, build.getBuildToolType());
         } catch (ApiException e) {

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/api/client/GradleEnterpriseApiClient.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/api/client/GradleEnterpriseApiClient.java
@@ -18,6 +18,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.tls.HandshakeCertificates;
 import org.jetbrains.annotations.NotNull;
 
+import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
@@ -116,8 +117,8 @@ public class GradleEnterpriseApiClient {
                     buildOutcomeFrom(attributes),
                     remoteBuildCacheUrlFrom(buildCachePerformance),
                     summarizeTaskExecutions(buildCachePerformance),
-                    toDuration(buildCachePerformance.getEffectiveTaskExecutionTime())
-                );
+                    toDuration(buildCachePerformance.getEffectiveTaskExecutionTime()),
+                    BigDecimal.valueOf(buildCachePerformance.getSerializationFactor()));
             }
             if (build.getBuildToolType().equalsIgnoreCase("maven")) {
                 MavenAttributes attributes = apiClient.getMavenAttributes(buildScanId, null);
@@ -134,8 +135,8 @@ public class GradleEnterpriseApiClient {
                     buildOutcomeFrom(attributes),
                     remoteBuildCacheUrlFrom(buildCachePerformance),
                     summarizeTaskExecutions(buildCachePerformance),
-                    toDuration(buildCachePerformance.getEffectiveProjectExecutionTime())
-                );
+                    toDuration(buildCachePerformance.getEffectiveProjectExecutionTime()),
+                    BigDecimal.valueOf(buildCachePerformance.getSerializationFactor()));
             }
             throw new UnknownBuildAgentException(baseUrl, buildScanId, build.getBuildToolType());
         } catch (ApiException e) {

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildValidationDataCommand.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildValidationDataCommand.java
@@ -11,6 +11,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -107,7 +108,8 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
                 "",
                 null,
                 Collections.emptyMap(),
-                Duration.ZERO);
+                Duration.ZERO,
+                BigDecimal.ZERO);
         }
     }
 

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
@@ -94,10 +94,10 @@ public enum Fields {
         return s.toString().trim();
     }
 
-    private static String formatBigDecimal(BigDecimal serializationFactor) {
-        if (serializationFactor.compareTo(BigDecimal.ZERO) == 0) {
+    private static String formatBigDecimal(BigDecimal value) {
+        if (value.compareTo(BigDecimal.ZERO) == 0) {
             return "";
         }
-        return serializationFactor.toPlainString();
+        return value.toPlainString();
     }
 }

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
@@ -4,7 +4,6 @@ import com.gradle.enterprise.model.BuildValidationData;
 import com.gradle.enterprise.model.TaskExecutionSummary;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Locale;
@@ -33,7 +32,7 @@ public enum Fields {
     EXECUTED_NOT_CACHEABLE("Executed not cacheable", d -> totalTasks(d, "executed_not_cacheable")),
     EXECUTED_NOT_CACHEABLE_DURATION("Executed not cacheable duration", d -> totalDuration(d, "executed_not_cacheable")),
     EFFECTIVE_TASK_EXECUTION_DURATION("Effective task execution duration", d -> String.valueOf(d.getEffectiveTaskExecutionDuration().toMillis())),
-    SERIALIZATION_FACTOR("Serialization factor", d -> formatSerializationFactor(d.getSerializationFactor())),
+    SERIALIZATION_FACTOR("Serialization factor", d -> formatBigDecimal(d.getSerializationFactor())),
     ;
 
     public final String label;
@@ -95,11 +94,10 @@ public enum Fields {
         return s.toString().trim();
     }
 
-    // todo get feedback on RoundingMode https://gradle.slack.com/archives/C012L0276KF/p1672437793010059
-    private static String formatSerializationFactor(BigDecimal serializationFactor) {
-        if (serializationFactor == null || serializationFactor.compareTo(BigDecimal.ZERO) == 0) {
+    private static String formatBigDecimal(BigDecimal serializationFactor) {
+        if (serializationFactor.compareTo(BigDecimal.ZERO) == 0) {
             return "";
         }
-        return String.valueOf(serializationFactor.setScale(1, RoundingMode.HALF_UP));
+        return serializationFactor.toPlainString();
     }
 }

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
@@ -3,6 +3,8 @@ package com.gradle.enterprise.cli;
 import com.gradle.enterprise.model.BuildValidationData;
 import com.gradle.enterprise.model.TaskExecutionSummary;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Locale;
@@ -31,6 +33,7 @@ public enum Fields {
     EXECUTED_NOT_CACHEABLE("Executed not cacheable", d -> totalTasks(d, "executed_not_cacheable")),
     EXECUTED_NOT_CACHEABLE_DURATION("Executed not cacheable duration", d -> totalDuration(d, "executed_not_cacheable")),
     EFFECTIVE_TASK_EXECUTION_DURATION("Effective task execution duration", d -> String.valueOf(d.getEffectiveTaskExecutionDuration().toMillis())),
+    SERIALIZATION_FACTOR("Serialization factor", d -> formatSerializationFactor(d.getSerializationFactor())),
     ;
 
     public final String label;
@@ -90,5 +93,13 @@ public enum Fields {
         s.append(String.format(Locale.ROOT, "%.3fs", seconds));
 
         return s.toString().trim();
+    }
+
+    // todo get feedback on RoundingMode https://gradle.slack.com/archives/C012L0276KF/p1672437793010059
+    private static String formatSerializationFactor(BigDecimal serializationFactor) {
+        if (serializationFactor == null || serializationFactor.compareTo(BigDecimal.ZERO) == 0) {
+            return "";
+        }
+        return String.valueOf(serializationFactor.setScale(1, RoundingMode.HALF_UP));
     }
 }

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/model/BuildValidationData.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/model/BuildValidationData.java
@@ -1,5 +1,6 @@
 package com.gradle.enterprise.model;
 
+import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
@@ -22,6 +23,7 @@ public class BuildValidationData {
     private final URL remoteBuildCacheUrl;
     private final Map<String, TaskExecutionSummary> tasksByAvoidanceOutcome;
     private final Duration effectiveTaskExecutionDuration;
+    private final BigDecimal serializationFactor;
 
     public BuildValidationData(
             String rootProjectName,
@@ -34,7 +36,8 @@ public class BuildValidationData {
             String buildOutcome,
             URL remoteBuildCacheUrl,
             Map<String, TaskExecutionSummary> tasksByAvoidanceOutcome,
-            Duration effectiveTaskExecutionDuration) {
+            Duration effectiveTaskExecutionDuration,
+            BigDecimal serializationFactor) {
         this.rootProjectName = rootProjectName;
         this.buildScanId = buildScanId;
         this.gradleEnterpriseServerUrl = gradleEnterpriseServerUrl;
@@ -46,6 +49,7 @@ public class BuildValidationData {
         this.remoteBuildCacheUrl = remoteBuildCacheUrl;
         this.tasksByAvoidanceOutcome = tasksByAvoidanceOutcome;
         this.effectiveTaskExecutionDuration = effectiveTaskExecutionDuration;
+        this.serializationFactor = serializationFactor;
     }
 
     public String getRootProjectName() {
@@ -141,5 +145,9 @@ public class BuildValidationData {
 
     public Duration getEffectiveTaskExecutionDuration() {
         return effectiveTaskExecutionDuration;
+    }
+
+    public BigDecimal getSerializationFactor() {
+        return serializationFactor;
     }
 }

--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -171,6 +171,8 @@ print_performance_characteristics() {
   print_performance_characteristics_header
 
   print_realized_build_time_savings
+
+  print_serialization_factor
 }
 
 print_quick_links() {

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -27,6 +27,7 @@ executed_not_cacheable_duration=()
 
 # Build duration metrics
 effective_task_execution_duration=()
+serialization_factors=()
 
 parse_build_scan_csv() {
   # This isn't the most robust way to read a CSV,
@@ -45,7 +46,7 @@ parse_build_scan_csv() {
   idx=0
 
   # shellcheck disable=SC2034 # not all scripts use all of the fetched data
-  while IFS=, read -r field_1 field_2 field_3 field_4 field_5 field_6 field_7 field_8 field_9 field_10 field_11 field_12 field_13 field_14 field_15 field_16 field_17 field_18 field_19 field_20; do
+  while IFS=, read -r field_1 field_2 field_3 field_4 field_5 field_6 field_7 field_8 field_9 field_10 field_11 field_12 field_13 field_14 field_15 field_16 field_17 field_18 field_19 field_20 field_21; do
     if [[ "$header_row_read" == "false" ]]; then
       header_row_read=true
       continue;
@@ -76,9 +77,13 @@ parse_build_scan_csv() {
     executed_not_cacheable_num_tasks[idx]="${field_18}"
     executed_not_cacheable_duration[idx]="${field_19}"
 
-    # Conditional because build-scan-support-tool does not yet support this field
+    # Conditional because build-scan-support-tool does not yet support these fields
     if [[ -n "$field_20" ]]; then
       effective_task_execution_duration[idx]="${field_20}"
+    fi
+
+    if [[ -n "$field_21" ]]; then
+      serialization_factors[idx]="${field_21}"
     fi
 
     ((idx++))

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -210,7 +210,7 @@ print_serialization_factor() {
   # Do not print serialization factor at all if this value does not exist
   # This can happen since build-scan-support-tool does not yet support this field
   if [[ -n "${serialization_factors[0]}" ]]; then
-    summary_row "Serialization factor:" "$(to_two_decimal_places "${serialization_factors[0]}")"
+    summary_row "Serialization factor:" "$(to_two_decimal_places "${serialization_factors[0]}")x"
   fi
 }
 

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -142,6 +142,8 @@ print_performance_characteristics() {
 
   print_build_caching_leverage_metrics
 
+  print_serialization_factor
+
   print_executed_cacheable_tasks_warning
 }
 
@@ -202,6 +204,14 @@ print_build_caching_leverage_metrics() {
     value="${taskCount} ${BUILD_TOOL_TASK}s, ${executed_not_cacheable_duration[1]} total execution time"
   fi
   summary_row "Executed non-cacheable ${BUILD_TOOL_TASK}s:" "${value}"
+}
+
+print_serialization_factor() {
+  # Do not print serialization factor at all if these values do not exist
+  # This can happen since build-scan-support-tool does not yet support these fields
+  if [[ -n "${serialization_factors[0]}" ]]; then
+    summary_row "Serialization factor:" "${serialization_factors[0]}"
+  fi
 }
 
 print_executed_cacheable_tasks_warning() {

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -293,5 +293,5 @@ format_duration() {
 # Rounds the argument to two decimal places
 # See: https://unix.stackexchange.com/a/167059
 to_two_decimal_places() {
-  echo "$1" | LC_ALL=C xargs printf "%.2f"
+  LC_ALL=C printf "%.2f" "$1"
 }

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -207,10 +207,10 @@ print_build_caching_leverage_metrics() {
 }
 
 print_serialization_factor() {
-  # Do not print serialization factor at all if these values do not exist
-  # This can happen since build-scan-support-tool does not yet support these fields
+  # Do not print serialization factor at all if this value does not exist
+  # This can happen since build-scan-support-tool does not yet support this field
   if [[ -n "${serialization_factors[0]}" ]]; then
-    summary_row "Serialization factor:" "${serialization_factors[0]}"
+    summary_row "Serialization factor:" "$(to_two_decimal_places "${serialization_factors[0]}")"
   fi
 }
 
@@ -288,4 +288,10 @@ format_duration() {
   fi
 
   printf "%d.%03ds" "${seconds}" "${millis}"
+}
+
+# Rounds the argument to two decimal places
+# See: https://unix.stackexchange.com/a/167059
+to_two_decimal_places() {
+  echo "$1" | LC_ALL=C xargs printf "%.2f"
 }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,3 @@
 - [NEW] Include realized build time savings in all experiment summaries
+- [NEW] Include serialization factor in all experiment summaries
 - [NEW] Support `-x` command line option for Gradle experiment 1 


### PR DESCRIPTION
## ❄️ Winter Update PR Navigator ❄️

1. #261
2. #262
3. #263
4. #264
5. #265
6. #266
7. #267
8. ⛄ #272
9. #274
10. #283

⛄ = you are here

## Summary

ℹ️ This PR continues the implementation of https://github.com/gradle/gradle-enterprise-build-validation-scripts/issues/206. This felt like a good place to stop. More PRs will be coming.

This PR updates the summary of all experiments to display the serialization factor of the first build. For example:

![image](https://user-images.githubusercontent.com/5797900/210430185-64e60d71-3d16-4b5c-afec-1ef908a724d0.png)

## Testing

To test this, I ran the following experiments and verified they displayed the serialization factor.

```sh
./01-validate-incremental-building.sh -r git@github.com:junit-team/junit5.git -t 'assemble' -s https://ge.solutions-team.gradle.com --debug
./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/7.x/ge -t 'build' -x --debug
./02-validate-local-build-caching-same-location.sh -r git@github.com:junit-team/junit5.git -t 'assemble' -s https://ge.solutions-team.gradle.com --debug
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/7.x/ge -t 'build' -x --debug
./03-validate-local-build-caching-different-locations.sh -r git@github.com:junit-team/junit5.git -t 'assemble' -s https://ge.solutions-team.gradle.com --debug
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/7.x/ge -t 'build' -x --debug
./04-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/atkuswzf5tqbe -2 https://ge.solutions-team.gradle.com/s/gso4oyqjeri4e --debug
./05-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/us4sfslrqlfnc -s https://ge.solutions-team.gradle.com --debug
./01-validate-local-build-caching-same-location.sh -r git@github.com:xwiki/xwiki-commons.git -g 'package' -a '-DskipTests' -s https://ge.solutions-team.gradle.com --debug
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/maven/3.8.x/ge -g 'package' -x --debug
./02-validate-local-build-caching-different-locations.sh -r git@github.com:xwiki/xwiki-commons.git -g 'package' -a '-DskipTests' -s https://ge.solutions-team.gradle.com --debug
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/maven/3.8.x/ge -g 'package' -x --debug
./03-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/o7i5lmq4vdckm -2 https://ge.solutions-team.gradle.com/s/qqfvwh2rft6yg --debug
./04-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/ehiqsjd2wh5qs -s https://ge.solutions-team.gradle.com --debug
```