### PR TITLE
Display potential build time savings in experiment summaries

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
@@ -33,6 +33,7 @@ public enum Fields {
     EXECUTED_NOT_CACHEABLE_DURATION("Executed not cacheable duration", d -> totalDuration(d, "executed_not_cacheable")),
     EFFECTIVE_TASK_EXECUTION_DURATION("Effective task execution duration", d -> String.valueOf(d.getEffectiveTaskExecutionDuration().toMillis())),
     SERIALIZATION_FACTOR("Serialization factor", d -> formatBigDecimal(d.getSerializationFactor())),
+    EXECUTED_CACHEABLE_DURATION_MILLISECONDS("Executed cacheable duration milliseconds", d -> totalDurationMillis(d, "executed_cacheable")),
     ;
 
     public final String label;
@@ -74,6 +75,15 @@ public enum Fields {
             data.getTasksByAvoidanceOutcome()
                 .getOrDefault(avoidanceOutcome, TaskExecutionSummary.ZERO)
                 .totalDuration()
+        );
+    }
+
+    private static String totalDurationMillis(BuildValidationData data, String avoidanceOutcome) {
+        return String.valueOf(
+            data.getTasksByAvoidanceOutcome()
+                .getOrDefault(avoidanceOutcome, TaskExecutionSummary.ZERO)
+                .totalDuration()
+                .toMillis()
         );
     }
 

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -28,6 +28,7 @@ executed_not_cacheable_duration=()
 # Build duration metrics
 effective_task_execution_duration=()
 serialization_factors=()
+executed_cacheable_duration_milliseconds=()
 
 parse_build_scan_csv() {
   # This isn't the most robust way to read a CSV,
@@ -46,7 +47,7 @@ parse_build_scan_csv() {
   idx=0
 
   # shellcheck disable=SC2034 # not all scripts use all of the fetched data
-  while IFS=, read -r field_1 field_2 field_3 field_4 field_5 field_6 field_7 field_8 field_9 field_10 field_11 field_12 field_13 field_14 field_15 field_16 field_17 field_18 field_19 field_20 field_21; do
+  while IFS=, read -r field_1 field_2 field_3 field_4 field_5 field_6 field_7 field_8 field_9 field_10 field_11 field_12 field_13 field_14 field_15 field_16 field_17 field_18 field_19 field_20 field_21 field_22; do
     if [[ "$header_row_read" == "false" ]]; then
       header_row_read=true
       continue;
@@ -84,6 +85,10 @@ parse_build_scan_csv() {
 
     if [[ -n "$field_21" ]]; then
       serialization_factors[idx]="${field_21}"
+    fi
+
+    if [[ -n "$field_22" ]]; then
+      executed_cacheable_duration_milliseconds[idx]="${field_22}"
     fi
 
     ((idx++))

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -140,6 +140,8 @@ print_performance_characteristics() {
 
   print_realized_build_time_savings
 
+  print_potential_build_time_savings
+
   print_build_caching_leverage_metrics
 
   print_serialization_factor
@@ -170,6 +172,34 @@ print_realized_build_time_savings() {
     fi
     summary_row "Realized build time savings:" "${value}"
   fi
+}
+
+print_potential_build_time_savings() {
+  local build_1_effective_execution_duration="${effective_task_execution_duration[0]}"
+
+  local build_2_effective_execution_duration="${effective_task_execution_duration[1]}"
+  local build_2_executed_cacheable_duration="${executed_cacheable_duration_milliseconds[1]}"
+  local build_2_serialization_factor="${serialization_factors[1]}"
+
+  # Do not print potential build time savings at all if these values do not exist
+  # This can happen since build-scan-support-tool does not yet support these fields
+  if [[ -z "${build_1_effective_execution_duration}" || -z "${build_2_effective_execution_duration}" || -z "${build_2_executed_cacheable_duration}" || -z "${build_2_serialization_factor}" ]]; then
+    return 0
+  fi
+
+  local value
+  value=""
+  # Only calculate realized build time savings when these have valid values
+  # These values can be returned as zero when an error occurs processing the Build Scan data
+  if [[ "${build_1_effective_execution_duration}" && "${build_2_effective_execution_duration}" && -n "${build_2_serialization_factor}" ]]; then
+    local first_build second_build potential_build_duration potential_savings
+    first_build=$(format_duration "${effective_task_execution_duration[0]}")
+    potential_build_duration=$(echo "${build_2_effective_execution_duration}-(${build_2_executed_cacheable_duration}/${build_2_serialization_factor})" | bc)
+    potential_savings=$(format_duration build_1_effective_execution_duration-potential_build_duration)
+    second_build=$(format_duration potential_build_duration)
+    value="${potential_savings} wall-clock time (from ${first_build} to ${second_build})"
+  fi
+  summary_row "Potential build time savings:" "${value}"
 }
 
 print_build_caching_leverage_metrics() {

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -194,6 +194,7 @@ print_potential_build_time_savings() {
   if [[ "${build_1_effective_execution_duration}" && "${build_2_effective_execution_duration}" && -n "${build_2_serialization_factor}" ]]; then
     local first_build second_build potential_build_duration potential_savings
     first_build=$(format_duration "${effective_task_execution_duration[0]}")
+    # shellcheck disable=SC2034 # it's used on the next few lines
     potential_build_duration=$(echo "${build_2_effective_execution_duration}-(${build_2_executed_cacheable_duration}/${build_2_serialization_factor})" | bc)
     potential_savings=$(format_duration build_1_effective_execution_duration-potential_build_duration)
     second_build=$(format_duration potential_build_duration)


### PR DESCRIPTION
## ❄️ Winter Update PR Navigator ❄️

1. #261
2. #262
3. #263
4. #264
5. #265
6. #266
7. #267
8. #272
9. ⛄ #274
10. #283

⛄ = you are here

## Summary

ℹ️ This PR continues the implementation of https://github.com/gradle/gradle-enterprise-build-validation-scripts/issues/206. This felt like a good place to stop. More PRs will be coming.

This PR adds the `potential_build_time` and `potential_build_time_savings`, which is calculated as:

```
potential_build_time = build_2_effective_duration - (build_2_executed_cacheable_duration / build_2_serialization_factor)
potential_build_time_savings = build_1_effective_duration - potential_build_time
```

This is then displayed to the user as in the following example:

![image](https://user-images.githubusercontent.com/5797900/210603550-1250428d-7644-434e-8816-b7762b0ef4ea.png)

## Testing

These changes were tested by running the following experiments and verifying they display a potential build time and potential build time savings. Note the exclusion of `exp5-gradle` and `exp4-maven`. I excluded these because I could not easily find a CI build with a cache miss.

```sh
./01-validate-incremental-building.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer' -s https://ge.solutions-team.gradle.com
./01-validate-incremental-building.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer' -s https://ge.solutions-team.gradle.com -x
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer' -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer' -s https://ge.solutions-team.gradle.com -x
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer' -s https://ge.solutions-team.gradle.com
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/androidx.git -p biometric -t 'buildOnServer' -s https://ge.solutions-team.gradle.com -x
./04-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/4jmo6kqqjnebg -2 https://ge.solutions-team.gradle.com/s/5bwb5ofenxrts
./01-validate-local-build-caching-same-location.sh -r git@github.com:OpenAPITools/openapi-generator.git -g 'package' -a '-DskipTests' -e -s https://ge.solutions-team.gradle.com
./01-validate-local-build-caching-same-location.sh -r git@github.com:OpenAPITools/openapi-generator.git -g 'package' -a '-DskipTests' -e -s https://ge.solutions-team.gradle.com -x
./02-validate-local-build-caching-different-locations.sh -r git@github.com:OpenAPITools/openapi-generator.git -g 'package' -a '-DskipTests' -e -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-different-locations.sh -r git@github.com:OpenAPITools/openapi-generator.git -g 'package' -a '-DskipTests' -e -s https://ge.solutions-team.gradle.com -x
./03-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/cdfz7q2whfxia -2 https://ge.solutions-team.gradle.com/s/2elplm2ff76am
```