### PR TITLE
Add ticks to improve readability of file path

### DIFF
--- a/Gradle.md
+++ b/Gradle.md
@@ -52,7 +52,7 @@ a specific experiment of the build validation process:
 | 05-validate-remote-build-caching-ci-local.sh | Validates that a Gradle build is optimized for remote build caching when invoked on CI agent and local machine. |
 </details>
 
-All intermediate and final output produced while running a given script is stored under .data/<script_name>/&lt;timestamp>-<run_id>.
+All intermediate and final output produced while running a given script is stored under `.data/<script_name>/<timestamp>-<run_id>`.
 
 ## Invocation
 
@@ -160,11 +160,11 @@ The summary looks typically like in the screenshot below.
 
 ## Investigating file resources on the local file system
 
-For the scripts that run one or more builds locally, the file resources that are used and produced by the builds can be investigated on the local file system. This is helpful when trying to understand cache misses due to changes in file inputs of the executed tasks. All intermediate and final output produced while running a given script is stored under .data/<script_name>/&lt;timestamp>-<run_id>.
+For the scripts that run one or more builds locally, the file resources that are used and produced by the builds can be investigated on the local file system. This is helpful when trying to understand cache misses due to changes in file inputs of the executed tasks. All intermediate and final output produced while running a given script is stored under `.data/<script_name>/<timestamp>-<run_id>`.
 
 Note that even when a script needs to run two builds from the same physical location, the individual builds are always preserved in separate folders, allowing to compare the same files from the two builds with each other.
 
-The folder hierarchy produced by the scripts under the .data folder looks typically like in the screenshot below.
+The folder hierarchy produced by the scripts under the `.data` folder looks typically like in the screenshot below.
 
 ![image](https://user-images.githubusercontent.com/231070/147548879-27a77148-bf24-4f9a-902e-460ce2f0c39d.png)
 

--- a/Maven.md
+++ b/Maven.md
@@ -50,7 +50,7 @@ a specific experiment of the build validation process:
 | 04-validate-remote-build-caching-ci-local.sh           | Validates that a Maven build is optimized for remote build caching when invoked on CI agent and local machine. |
 </details>
 
-All intermediate and final output produced while running a given script is stored under .data/<script_name>/&lt;timestamp>-<run_id>.
+All intermediate and final output produced while running a given script is stored under `.data/<script_name>/<timestamp>-<run_id>`.
 
 ## Invocation
 
@@ -158,11 +158,11 @@ The summary looks typically like in the screenshot below.
 
 ## Investigating file resources on the local file system
 
-For the scripts that run one or more builds locally, the file resources that are used and produced by the builds can be investigated on the local file system. This is helpful when trying to understand cache misses due to changes in file inputs of the executed goals. All intermediate and final output produced while running a given script is stored under .data/<script_name>/&lt;timestamp>-<run_id>.
+For the scripts that run one or more builds locally, the file resources that are used and produced by the builds can be investigated on the local file system. This is helpful when trying to understand cache misses due to changes in file inputs of the executed goals. All intermediate and final output produced while running a given script is stored under `.data/<script_name>/<timestamp>-<run_id>`.
 
 Note that even when a script needs to run two builds from the same physical location, the individual builds are always preserved in separate folders, allowing to compare the same files from the two builds with each other.
 
-The folder hierarchy produced by the scripts under the .data folder looks typically like in the screenshot below.
+The folder hierarchy produced by the scripts under the `.data` folder looks typically like in the screenshot below.
 
 ![image](https://user-images.githubusercontent.com/231070/147553179-a6def855-8813-41c2-a8d5-071cbd0150bc.png)
 


### PR DESCRIPTION
Here's a quick link to what this looks like rendered in the README: https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/no/add-ticks/Gradle.md#investigating-file-resources-on-the-local-file-system