### PR TITLE
Fix incorrect parsing of additional argument values containing spaces

### DIFF
--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -34,8 +34,11 @@ invoke_gradle() {
     -Dscan.capture-task-input-files=true
   )
 
-  # shellcheck disable=SC2206
-  args+=(${extra_args})
+  # https://stackoverflow.com/a/31485948
+  while IFS= read -r -d ''; do
+    args+=("$REPLY")
+  done < <( xargs printf '%s\0' <<< "$extra_args")
+
   args+=("$@")
 
   rm -f "${EXP_DIR}/build-scan-publish-error.txt"

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -62,8 +62,11 @@ invoke_maven() {
     args+=("-Dgradle.enterprise.url=${ge_server}")
   fi
 
-  # shellcheck disable=SC2206
-  args+=(${extra_args})
+  # https://stackoverflow.com/a/31485948
+  while IFS= read -r -d ''; do
+    args+=("$REPLY")
+  done < <( xargs printf '%s\0' <<< "$extra_args")
+
   args+=("$@")
 
   debug "Current directory: $(pwd)"

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,3 +1,4 @@
 - [NEW] Include realized build time savings in all experiment summaries
 - [NEW] Include serialization factor in all experiment summaries
-- [NEW] Support `-x` command line option for Gradle experiment 1 
+- [NEW] Support `-x` command line option for Gradle experiment 1
+- [FIX] Incorrect parsing of additional argument values containing spaces


### PR DESCRIPTION
This PR changes how extra arguments (`-a` / `--args`) are parsed for both Maven and Gradle. Consider the following experiment:

```shell
./01-validate-incremental-building.sh \
  -r https://github.com/gradle/common-custom-user-data-gradle-plugin \
  -t build \
  -a '--no-configuration-cache -Pfooo=barr -Pfoo=bar -Porg.gradle.jvmargs=-Xmx1g\ -XX:MaxMetaspaceSize=512m'
```

Previously, both executions would fail with the following error:

![image](https://user-images.githubusercontent.com/5797900/218186557-d4b0c2e1-c263-4dfe-9255-2aa3ec0d869e.png)

Regardless of how you quote wrap or escape the arguments, the result will be the same. 

This PR updates the logic to parse the additional arguments to use a more sophisticated approach. With these changes, the above example completes successfully:

![image](https://user-images.githubusercontent.com/5797900/218187613-d81fb498-e1fe-498c-9fd3-096f98a2808c.png)

Fixes #299 