### PR TITLE
Remove explicit task dependency for Gradle 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -236,14 +236,9 @@ tasks.check {
 val generateChecksums by tasks.registering(Checksum::class) {
     group = "distribution"
     description = "Generates checksums for the distribution zip files."
-    inputFiles.setFrom(assembleGradleScripts.flatMap { gradleScripts: Zip ->
-        assembleMavenScripts.map { mavenScripts: Zip ->
-            gradleScripts.outputs.files.plus(mavenScripts.outputs.files)
-        }
-    })
+    inputFiles.setFrom(assembleGradleScripts, assembleMavenScripts)
     outputDirectory.set(layout.buildDirectory.dir("distributions/checksums").get().asFile)
     checksumAlgorithm.set(Checksum.Algorithm.SHA512)
-    dependsOn(assembleGradleScripts, assembleMavenScripts)
 }
 
 val isDevelopmentRelease = !hasProperty("finalRelease")


### PR DESCRIPTION
Rather than having an explicit dependency from `generateChecksums` to the `assembleScript` Zip tasks, this change declares the two tasks as being inputs to `generateChecksums`

Fixes #308 