### PR TITLE
Remove redundant Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,18 +12,6 @@ updates:
       - gradle-plugin-portal
     schedule:
       interval: "daily"
-  - package-ecosystem: "gradle"
-    directory: "components/capture-build-scan-url-maven-extension"
-    registries:
-      - gradle-plugin-portal
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gradle"
-    directory: "components/fetch-build-scan-data-cmdline-tool"
-    registries:
-      - gradle-plugin-portal
-    schedule:
-      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This is causing duplicate Dependabot PRs. For example, #317 and #318.