### PR TITLE
Bump com.gradle.enterprise from 3.12.3 to 3.12.4

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.GradleVersion
 import java.nio.charset.StandardCharsets;
 
 initscript {
-    def gradleEnterprisePluginVersion = "3.12.3"
+    def gradleEnterprisePluginVersion = "3.12.4"
 
     repositories {
         gradlePluginPortal()

--- a/components/scripts/gradle/gradle-init-scripts/enable-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/enable-gradle-enterprise.gradle
@@ -4,7 +4,7 @@ import com.gradle.CommonCustomUserDataGradlePlugin
 import org.gradle.util.GradleVersion
 
 initscript {
-    def gradleEnterprisePluginVersion = "3.12.3"
+    def gradleEnterprisePluginVersion = "3.12.4"
     def commonCustomUserDataPluginVersion = "1.9"
 
     repositories {


### PR DESCRIPTION
This PR updates the Gradle Enterprise Gradle plugin version from `3.12.3` to `3.12.4` in the Gradle initialization scripts. 