### PR TITLE
Update performance characteristics to show initial, instant, and pending build times

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/api/client/GradleEnterpriseApiClient.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/api/client/GradleEnterpriseApiClient.java
@@ -139,7 +139,7 @@ public class GradleEnterpriseApiClient {
                     buildOutcomeFrom(attributes),
                     remoteBuildCacheUrlFrom(buildCachePerformance),
                     summarizeTaskExecutions(buildCachePerformance),
-                    toDuration(buildCachePerformance.getEffectiveTaskExecutionTime()),
+                    toDuration(buildCachePerformance.getBuildTime()),
                     BigDecimal.valueOf(buildCachePerformance.getSerializationFactor())
                 );
             }
@@ -158,7 +158,7 @@ public class GradleEnterpriseApiClient {
                     buildOutcomeFrom(attributes),
                     remoteBuildCacheUrlFrom(buildCachePerformance),
                     summarizeTaskExecutions(buildCachePerformance),
-                    toDuration(buildCachePerformance.getEffectiveProjectExecutionTime()),
+                    toDuration(buildCachePerformance.getBuildTime()),
                     BigDecimal.valueOf(buildCachePerformance.getSerializationFactor())
                 );
             }

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/Fields.java
@@ -30,7 +30,7 @@ public enum Fields {
     EXECUTED_CACHEABLE_DURATION("Executed cacheable duration", d -> totalDuration(d, "executed_cacheable")),
     EXECUTED_NOT_CACHEABLE("Executed not cacheable", d -> totalTasks(d, "executed_not_cacheable")),
     EXECUTED_NOT_CACHEABLE_DURATION("Executed not cacheable duration", d -> totalDuration(d, "executed_not_cacheable")),
-    EFFECTIVE_TASK_EXECUTION_DURATION("Effective task execution duration", d -> formatDuration(d.getEffectiveTaskExecutionDuration())),
+    BUILD_TIME("Build time", d -> formatDuration(d.getBuildTime())),
     SERIALIZATION_FACTOR("Serialization factor", d -> toStringSafely(d.getSerializationFactor())),
     ;
 

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/model/BuildValidationData.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/model/BuildValidationData.java
@@ -22,7 +22,7 @@ public class BuildValidationData {
     private final String buildOutcome;
     private final URL remoteBuildCacheUrl;
     private final Map<String, TaskExecutionSummary> tasksByAvoidanceOutcome;
-    private final Duration effectiveTaskExecutionDuration;
+    private final Duration buildTime;
     private final BigDecimal serializationFactor;
 
     public BuildValidationData(
@@ -36,7 +36,7 @@ public class BuildValidationData {
             String buildOutcome,
             URL remoteBuildCacheUrl,
             Map<String, TaskExecutionSummary> tasksByAvoidanceOutcome,
-            Duration effectiveTaskExecutionDuration,
+            Duration buildTime,
             BigDecimal serializationFactor) {
         this.rootProjectName = rootProjectName;
         this.buildScanId = buildScanId;
@@ -48,7 +48,7 @@ public class BuildValidationData {
         this.buildOutcome = buildOutcome;
         this.remoteBuildCacheUrl = remoteBuildCacheUrl;
         this.tasksByAvoidanceOutcome = tasksByAvoidanceOutcome;
-        this.effectiveTaskExecutionDuration = effectiveTaskExecutionDuration;
+        this.buildTime = buildTime;
         this.serializationFactor = serializationFactor;
     }
 
@@ -127,8 +127,8 @@ public class BuildValidationData {
         return tasksByAvoidanceOutcome;
     }
 
-    public Duration getEffectiveTaskExecutionDuration() {
-        return effectiveTaskExecutionDuration;
+    public Duration getBuildTime() {
+        return buildTime;
     }
 
     public BigDecimal getSerializationFactor() {

--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -165,7 +165,9 @@ fetch_build_cache_metrics() {
 print_performance_characteristics() {
   print_performance_characteristics_header
 
-  print_realized_build_time_savings
+  print_initial_build_time
+
+  print_instant_build_time_savings
 
   print_serialization_factor
 }

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -26,7 +26,7 @@ executed_not_cacheable_num_tasks=()
 executed_not_cacheable_duration=()
 
 # Build duration metrics
-effective_task_execution_duration=()
+build_time=()
 serialization_factors=()
 
 parse_build_scan_csv() {
@@ -77,8 +77,8 @@ parse_build_scan_csv() {
     executed_not_cacheable_num_tasks[idx]="${field_18}"
     executed_not_cacheable_duration[idx]="${field_19}"
 
-    # Build duration metrics
-    effective_task_execution_duration[idx]="${field_20}"
+    # Build time metrics
+    build_time[idx]="${field_20}"
     serialization_factors[idx]="${field_21}"
 
     ((idx++))

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -188,10 +188,9 @@ print_pending_build_time_savings() {
         -n "${executed_cacheable_duration[1]}" && \
         -n "${serialization_factors[1]}" ]]
   then
-    local instant_build_time_savings pending_additional_build_time_savings pending_build_time
-    instant_build_time_savings=$((build_time[0]-build_time[1]))
+    local pending_additional_build_time_savings pending_build_time
     pending_additional_build_time_savings=$(echo "${executed_cacheable_duration[1]}/${serialization_factors[1]}" | bc)
-    pending_build_time=$((build_time[0]-instant_build_time_savings-pending_additional_build_time_savings))
+    pending_build_time=$((build_time[1]-pending_additional_build_time_savings))
     printf -v value "%s, %s additional savings" \
       "$(format_duration "${pending_build_time}")" \
       "$(format_duration "${pending_additional_build_time_savings}")"

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -160,8 +160,8 @@ print_performance_characteristics_header() {
 # The _initial_ build time is the build time of the first build.
 print_initial_build_time() {
   local value
-  if [[ -n "${effective_task_execution_duration[0]}" ]]; then
-    value="$(format_duration "${effective_task_execution_duration[0]}")"
+  if [[ -n "${build_time[0]}" ]]; then
+    value="$(format_duration "${build_time[0]}")"
   fi
   summary_row "Initial build time:" "${value}"
 }
@@ -170,10 +170,10 @@ print_initial_build_time() {
 # time between the first and second build.
 print_instant_build_time_savings() {
   local value
-  if [[ -n "${effective_task_execution_duration[0]}" && -n "${effective_task_execution_duration[1]}" ]]; then
-    local instant_build_time_savings=$((effective_task_execution_duration[0]-effective_task_execution_duration[1]))
+  if [[ -n "${build_time[0]}" && -n "${build_time[1]}" ]]; then
+    local instant_build_time_savings=$((build_time[0]-build_time[1]))
     printf -v value "%s, %s savings" \
-      "$(format_duration "${effective_task_execution_duration[1]}")" \
+      "$(format_duration "${build_time[1]}")" \
       "$(format_duration "${instant_build_time_savings}")"
   fi
   summary_row "Build time with instant savings:" "${value}"
@@ -183,15 +183,15 @@ print_instant_build_time_savings() {
 # tasks had been executed.
 print_pending_build_time_savings() {
   local value
-  if [[ -n "${effective_task_execution_duration[0]}" && \
-        -n "${effective_task_execution_duration[1]}" && \
+  if [[ -n "${build_time[0]}" && \
+        -n "${build_time[1]}" && \
         -n "${executed_cacheable_duration[1]}" && \
         -n "${serialization_factors[1]}" ]]
   then
     local instant_build_time_savings pending_additional_build_time_savings pending_build_time
-    instant_build_time_savings=$((effective_task_execution_duration[0]-effective_task_execution_duration[1]))
+    instant_build_time_savings=$((build_time[0]-build_time[1]))
     pending_additional_build_time_savings=$(echo "${executed_cacheable_duration[1]}/${serialization_factors[1]}" | bc)
-    pending_build_time=$((effective_task_execution_duration[0]-instant_build_time_savings-pending_additional_build_time_savings))
+    pending_build_time=$((build_time[0]-instant_build_time_savings-pending_additional_build_time_savings))
     printf -v value "%s, %s additional savings" \
       "$(format_duration "${pending_build_time}")" \
       "$(format_duration "${pending_additional_build_time_savings}")"

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -183,8 +183,7 @@ print_instant_build_time_savings() {
 # tasks had been executed.
 print_pending_build_time_savings() {
   local value
-  if [[ -n "${build_time[0]}" && \
-        -n "${build_time[1]}" && \
+  if [[ -n "${build_time[1]}" && \
         -n "${executed_cacheable_duration[1]}" && \
         -n "${serialization_factors[1]}" ]]
   then

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly SUMMARY_FMT="%-30s%s"
+readonly SUMMARY_FMT="%-33s%s"
 readonly ORDINALS=( first second third fourth fifth sixth seventh eighth ninth tenth )
 
 warnings=()
@@ -138,9 +138,11 @@ print_experiment_specific_summary_info() {
 print_performance_characteristics() {
   print_performance_characteristics_header
 
-  print_realized_build_time_savings
+  print_initial_build_time
 
-  print_potential_build_time_savings
+  print_instant_build_time_savings
+
+  print_pending_build_time_savings
 
   print_build_caching_leverage_metrics
 
@@ -155,45 +157,46 @@ print_performance_characteristics_header() {
   info "---------------------------"
 }
 
-# The _realized_ build time savings is the difference in the wall-clock build
-# time between the first and second build.
-print_realized_build_time_savings() {
+# The _initial_ build time is the build time of the first build.
+print_initial_build_time() {
   local value
-  # Only calculate realized build time savings when these values exist
-  # These values can be returned as empty when an error occurs processing the Build Scan data
-  if [[ -n "${effective_task_execution_duration[0]}" && -n "${effective_task_execution_duration[1]}" ]]; then
-    local realized_build_time_savings=$((effective_task_execution_duration[0]-effective_task_execution_duration[1]))
-    printf -v value "%s wall-clock time (from %s to %s)" \
-      "$(format_duration "${realized_build_time_savings}")" \
-      "$(format_duration "${effective_task_execution_duration[0]}")" \
-      "$(format_duration "${effective_task_execution_duration[1]}")"
+  if [[ -n "${effective_task_execution_duration[0]}" ]]; then
+    value="$(format_duration "${effective_task_execution_duration[0]}")"
   fi
-  summary_row "Realized build time savings:" "${value}"
+  summary_row "Initial build time:" "${value}"
 }
 
-# The _potential_ build time savings is the difference in wall-clock build time
-# between the first build and the _potential_ build time of the second build.
-#
-# The _potential_ build time is an estimation of the build time if no cacheable
-# tasks had been executed.
-print_potential_build_time_savings() {
+# The _instant_ build time savings is the difference in the wall-clock build
+# time between the first and second build.
+print_instant_build_time_savings() {
   local value
-  # Only calculate realized build time savings when these values exist
-  # These values can be returned as empty when an error occurs processing the Build Scan data
+  if [[ -n "${effective_task_execution_duration[0]}" && -n "${effective_task_execution_duration[1]}" ]]; then
+    local instant_build_time_savings=$((effective_task_execution_duration[0]-effective_task_execution_duration[1]))
+    printf -v value "%s, %s savings" \
+      "$(format_duration "${effective_task_execution_duration[1]}")" \
+      "$(format_duration "${instant_build_time_savings}")"
+  fi
+  summary_row "Build time with instant savings:" "${value}"
+}
+
+# The _pending_ build time is an estimation of the build time if no cacheable
+# tasks had been executed.
+print_pending_build_time_savings() {
+  local value
   if [[ -n "${effective_task_execution_duration[0]}" && \
         -n "${effective_task_execution_duration[1]}" && \
         -n "${executed_cacheable_duration[1]}" && \
         -n "${serialization_factors[1]}" ]]
   then
-    local potential_build_time potential_build_time_savings
-    potential_build_time=$(echo "${effective_task_execution_duration[1]}-(${executed_cacheable_duration[1]}/${serialization_factors[1]})" | bc)
-    potential_build_time_savings=$((effective_task_execution_duration[0]-potential_build_time))
-    printf -v value "%s wall-clock time (from %s to %s)" \
-      "$(format_duration "${potential_build_time_savings}")" \
-      "$(format_duration "${effective_task_execution_duration[0]}")" \
-      "$(format_duration "${potential_build_time}")"
+    local instant_build_time_savings pending_additional_build_time_savings pending_build_time
+    instant_build_time_savings=$((effective_task_execution_duration[0]-effective_task_execution_duration[1]))
+    pending_additional_build_time_savings=$(echo "${executed_cacheable_duration[1]}/${serialization_factors[1]}" | bc)
+    pending_build_time=$((effective_task_execution_duration[0]-instant_build_time_savings-pending_additional_build_time_savings))
+    printf -v value "%s, %s additional savings" \
+      "$(format_duration "${pending_build_time}")" \
+      "$(format_duration "${pending_additional_build_time_savings}")"
   fi
-  summary_row "Potential build time savings:" "${value}"
+  summary_row "Build time with pending savings:" "${value}"
 }
 
 print_build_caching_leverage_metrics() {

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -179,8 +179,8 @@ print_instant_build_time_savings() {
   summary_row "Build time with instant savings:" "${value}"
 }
 
-# The _pending_ build time is an estimation of the build time if no cacheable
-# tasks had been executed.
+# The _pending_ build time is an estimation of the build time if all cacheable
+# tasks had been avoided.
 print_pending_build_time_savings() {
   local value
   if [[ -n "${build_time[1]}" && \


### PR DESCRIPTION
This PR updates the performance characteristics section to display 3 "build time" metrics. They are:

- Initial build time: The build time of the first build
- Instant build time savings: The immediate savings as a result of build caching. 
- Pending build time savings: An estimate of the potential savings if all executed cacheable tasks had come from cache.

Example output of Gradle experiments 2-5 and Maven experiments 1-4:

```
Performance Characteristics
---------------------------
Initial build time:              16.284s
Build time with instant savings: 3.520s, 12.764s savings
Build time with pending savings: 3.520s, 0.000s additional savings
Avoided cacheable tasks:          63 tasks, 1m 21.524s total saved execution time
Executed cacheable tasks:          0 tasks, 0.000s total execution time
Executed non-cacheable tasks:    118 tasks, 6.167s total execution time
Serialization factor:            4.97x
```

Example output of Gradle experiment 1:

```
Performance Characteristics
---------------------------
Initial build time:              23.605s
Build time with instant savings: 1.945s, 21.660s savings
Serialization factor:            3.59x
```
