### PR TITLE
Better handle cases where builds fail because the JVM exits unexpectedly

### DIFF
--- a/components/capture-build-scan-url-maven-extension/src/main/java/com/gradle/CaptureBuildScansListener.java
+++ b/components/capture-build-scan-url-maven-extension/src/main/java/com/gradle/CaptureBuildScansListener.java
@@ -71,7 +71,7 @@ public class CaptureBuildScansListener implements GradleEnterpriseListener {
     private void capturePublishedBuildScan(BuildScanApi buildScan) {
         buildScan.buildScanPublished(scan -> {
             logger.debug("Saving build scan data to build-scans.csv");
-            String buildNumber = System.getProperty("com.gradle.enterprise.build_validation.build_number");
+            String buildNumber = System.getProperty("com.gradle.enterprise.build_validation.buildNumber");
             String port = scan.getBuildScanUri().getPort() != -1 ? ":" + scan.getBuildScanUri().getPort() : "";
             String baseUrl = String.format("%s://%s%s", scan.getBuildScanUri().getScheme(), scan.getBuildScanUri().getHost(), port);
 

--- a/components/capture-build-scan-url-maven-extension/src/main/java/com/gradle/CaptureBuildScansListener.java
+++ b/components/capture-build-scan-url-maven-extension/src/main/java/com/gradle/CaptureBuildScansListener.java
@@ -71,13 +71,14 @@ public class CaptureBuildScansListener implements GradleEnterpriseListener {
     private void capturePublishedBuildScan(BuildScanApi buildScan) {
         buildScan.buildScanPublished(scan -> {
             logger.debug("Saving build scan data to build-scans.csv");
+            String buildNumber = System.getProperty("com.gradle.enterprise.build_validation.build_number");
             String port = scan.getBuildScanUri().getPort() != -1 ? ":" + scan.getBuildScanUri().getPort() : "";
             String baseUrl = String.format("%s://%s%s", scan.getBuildScanUri().getScheme(), scan.getBuildScanUri().getHost(), port);
 
             try (FileWriter fw = new FileWriter(EXPERIMENT_DIR + "/build-scans.csv", true);
                 BufferedWriter bw = new BufferedWriter(fw);
                 PrintWriter out = new PrintWriter(bw)) {
-               out.println(String.format("%s,%s,%s", baseUrl, scan.getBuildScanUri(), scan.getBuildScanId()));
+               out.println(String.format("%s,%s,%s,%s", buildNumber, baseUrl, scan.getBuildScanUri(), scan.getBuildScanId()));
             } catch (IOException e) {
                 logger.error("Unable to save scan data to build-scans.csv: " + e.getMessage(), e);
                 throw new RuntimeException("Unable to save scan data to build-scans.csv: " + e.getMessage(), e);

--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -129,18 +129,22 @@ wizard_execute() {
 # shellcheck disable=SC2086 # splitting expected
 execute_first_build() {
   info "Running first build:"
-  execute_build clean ${tasks}
+  execute_build 0 clean ${tasks}
 }
 
 # shellcheck disable=SC2086 # splitting expected
 execute_second_build() {
   info "Running second build:"
-  execute_build ${tasks}
+  execute_build 1 ${tasks}
 }
 
 execute_build() {
+  local build_number
+  build_number="$1"
+  shift
+
   print_gradle_command "$@"
-  invoke_gradle --no-build-cache "$@"
+  invoke_gradle "${build_number}" --no-build-cache "$@"
 }
 
 print_gradle_command() {

--- a/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -130,19 +130,23 @@ wizard_execute() {
 
 execute_first_build() {
   info "Running first build:"
-  execute_build
+  execute_build 0
 }
 
 execute_second_build() {
   info "Running second build:"
-  execute_build
+  execute_build 1
 }
 
 execute_build() {
+  local build_number
+  build_number="$1"
+  shift
+
   print_gradle_command
 
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
-  invoke_gradle \
+  invoke_gradle "${build_number}" \
      --build-cache \
      --init-script "${INIT_SCRIPTS_DIR}/configure-local-build-caching.gradle" \
      clean ${tasks}

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -173,18 +173,6 @@ fetch_build_cache_metrics() {
   fi
 }
 
-print_quick_links() {
-  info "Investigation Quick Links"
-  info "-------------------------"
-  quick_link_row "Task execution overview:" "${base_urls[1]}/s/${build_scan_ids[1]}/performance/execution" "${base_urls[1]}" "${build_scan_ids[1]}"
-  quick_link_row "Executed tasks timeline:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
-  quick_link_row "Avoided cacheable tasks:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?outcome=from-cache&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
-  quick_link_row "Executed cacheable tasks:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
-  quick_link_row "Executed non-cacheable tasks:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?cacheability=any-non-cacheable,not:overlapping-outputs,not:validation-failure&outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
-  quick_link_row "Build caching statistics:" "${base_urls[1]}/s/${build_scan_ids[1]}/performance/build-cache" "${base_urls[1]}" "${build_scan_ids[1]}"
-  quick_link_row "Task inputs comparison:" "${base_urls[1]}/c/${build_scan_ids[0]}/${build_scan_ids[1]}/task-inputs?cacheability=cacheable" "${base_urls[1]}" "${build_scan_ids[0]}" "${build_scan_ids[1]}"
-}
-
 print_introduction() {
   local text
   IFS='' read -r -d '' text <<EOF

--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -117,31 +117,8 @@ validate_required_args() {
 }
 
 parse_build_scan_urls() {
-  # From https://stackoverflow.com/a/63993578/106189
-  # See also https://stackoverflow.com/a/45977232/106189
-  readonly URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?((/|$)([^?#]*))(\?([^#]*))?(#(.*))?$'
-  #                    ↑↑            ↑  ↑↑↑            ↑         ↑ ↑            ↑↑    ↑        ↑  ↑        ↑ ↑
-  #                    ||            |  |||            |         | |            ||    |        |  |        | |
-  #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       ||    12 rpath |  14 query | 16 fragment
-  #                    1 scheme:     |  |5 userinfo@             8 :...         ||             13 ?...     15 #...
-  #                                  |  4 authority                             |11 / or end-of-string
-  #                                  3  //...                                   10 path
-
-  local protocol ge_host port build_scan_id
-
-  for url in "${build_scan_urls[@]}"; do
-    if [[ "${url}" =~ $URI_REGEX ]]; then
-      protocol="${BASH_REMATCH[2]}"
-      ge_host="${BASH_REMATCH[7]}"
-      port="${BASH_REMATCH[8]}"
-      build_scan_id="$(basename "${BASH_REMATCH[10]}")"
-
-      base_urls+=("${protocol}://${ge_host}${port}")
-      build_scan_ids+=("$build_scan_id")
-    else
-      die "${url} is not a parsable URL." "${INVALID_INPUT}"
-    fi
-  done
+  parse_build_scan_url "${build_scan_urls[0]}" 0
+  parse_build_scan_url "${build_scan_urls[1]}" 1
 }
 
 fetch_build_scans() {

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -150,6 +150,7 @@ validate_required_args() {
 }
 
 fetch_build_params_from_build_scan() {
+  parse_build_scan_url "${ci_build_scan_url}" 0
   fetch_and_read_build_scan_data all_data "${ci_build_scan_url}"
   read_build_params_from_build_scan_data
 }

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -205,7 +205,7 @@ execute_build() {
   info "Running build:"
   info "./gradlew --build-cache --scan -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} clean ${tasks}$(print_extra_args)"
 
-  invoke_gradle "${args[@]}"
+  invoke_gradle 1 "${args[@]}"
 }
 
 # Overrides info.sh#print_experiment_specific_summary_info

--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -81,11 +81,12 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
 def registerBuildScanActions = { def buildScan ->
     def scanFile = new File(experimentDir, 'build-scans.csv')
     buildScan.buildScanPublished { publishedBuildScan ->
+        def buildNumber = System.getProperty("com.gradle.enterprise.build_validation.build_number")
         def buildScanUri = publishedBuildScan.buildScanUri
         def buildScanId = publishedBuildScan.buildScanId
         def port = (buildScanUri.port != -1) ? ':' + buildScanUri.port : ''
         def baseUrl = "${buildScanUri.scheme}://${buildScanUri.host}${port}"
-        scanFile.append("${baseUrl},${buildScanUri},${buildScanId}\n")
+        scanFile.append("${buildNumber},${baseUrl},${buildScanUri},${buildScanId}\n")
     }
 
     def errorFile = new File(experimentDir, 'build-scan-publish-error.txt')

--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -81,7 +81,7 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
 def registerBuildScanActions = { def buildScan ->
     def scanFile = new File(experimentDir, 'build-scans.csv')
     buildScan.buildScanPublished { publishedBuildScan ->
-        def buildNumber = System.getProperty("com.gradle.enterprise.build_validation.build_number")
+        def buildNumber = System.getProperty("com.gradle.enterprise.build_validation.buildNumber")
         def buildScanUri = publishedBuildScan.buildScanUri
         def buildScanId = publishedBuildScan.buildScanId
         def port = (buildScanUri.port != -1) ? ':' + buildScanUri.port : ''

--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -64,10 +64,6 @@ def getInputParam = { String name ->
     return System.getProperty(name) ?: System.getenv(envVarName)
 }
 
-if (getInputParam("com.gradle.enterprise.build_validation.buildNumber") == "0") {
-    System.exit(100)
-}
-
 def geUrl = getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.allow-untrusted-server'))
 def gePluginVersion = getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.plugin.version')

--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -64,6 +64,10 @@ def getInputParam = { String name ->
     return System.getProperty(name) ?: System.getenv(envVarName)
 }
 
+if (getInputParam("com.gradle.enterprise.build_validation.buildNumber") == "0") {
+    System.exit(100)
+}
+
 def geUrl = getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.allow-untrusted-server'))
 def gePluginVersion = getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.plugin.version')
@@ -81,7 +85,7 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
 def registerBuildScanActions = { def buildScan ->
     def scanFile = new File(experimentDir, 'build-scans.csv')
     buildScan.buildScanPublished { publishedBuildScan ->
-        def buildNumber = System.getProperty("com.gradle.enterprise.build_validation.buildNumber")
+        def buildNumber = getInputParam("com.gradle.enterprise.build_validation.buildNumber")
         def buildScanUri = publishedBuildScan.buildScanUri
         def buildScanId = publishedBuildScan.buildScanId
         def port = (buildScanUri.port != -1) ? ':' + buildScanUri.port : ''

--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -68,6 +68,7 @@ def geUrl = getInputParam('com.gradle.enterprise.build_validation.gradle-enterpr
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.allow-untrusted-server'))
 def gePluginVersion = getInputParam('com.gradle.enterprise.build_validation.gradle-enterprise.plugin.version')
 def ccudPluginVersion = getInputParam('com.gradle.enterprise.build_validation.ccud.plugin.version')
+def buildNumber = getInputParam("com.gradle.enterprise.build_validation.buildNumber")
 
 def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
@@ -81,7 +82,6 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
 def registerBuildScanActions = { def buildScan ->
     def scanFile = new File(experimentDir, 'build-scans.csv')
     buildScan.buildScanPublished { publishedBuildScan ->
-        def buildNumber = getInputParam("com.gradle.enterprise.build_validation.buildNumber")
         def buildScanUri = publishedBuildScan.buildScanUri
         def buildScanId = publishedBuildScan.buildScanId
         def port = (buildScanUri.port != -1) ? ':' + buildScanUri.port : ''

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -52,12 +52,13 @@ parse_build_scan_csv() {
       continue;
     fi
 
+    idx="$(find_build_number "$field_4")"
+    debug "Build Scan $field_4 is for build $idx"
     project_names[idx]="$field_1"
 
     if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
       base_urls[idx]="$field_2"
       build_scan_urls[idx]="$field_3"
-      build_scan_ids[idx]="$field_4"
       git_repos[idx]="$field_5"
       git_branches[idx]="$field_6"
       git_commit_ids[idx]="$field_7"
@@ -81,6 +82,17 @@ parse_build_scan_csv() {
     effective_task_execution_duration[idx]="${field_20}"
     serialization_factors[idx]="${field_21}"
 
-    ((idx++))
     done <<< "${build_scan_csv}"
+}
+
+find_build_number() {
+  local build_scan_id
+  build_scan_id="$1"
+
+  idx=0
+  for i in "${!build_scan_ids[@]}"; do
+    [[ "${build_scan_ids[$i]}" == "${build_scan_id}" ]] && idx="$i"
+  done
+
+  echo "$idx"
 }

--- a/components/scripts/lib/build_scan.sh
+++ b/components/scripts/lib/build_scan.sh
@@ -24,10 +24,10 @@ read_build_scan_metadata() {
       debug ""
     fi
 
-    while IFS=, read -r field_1 field_2 field_3; do
-       base_urls+=("$field_1")
-       build_scan_urls+=("$field_2")
-       build_scan_ids+=("$field_3")
+    while IFS=, read -r build_number field_1 field_2 field_3; do
+       base_urls[$build_number]="$field_1"
+       build_scan_urls[$build_number]="$field_2"
+       build_scan_ids[$build_number]="$field_3"
     done <<< "${build_scan_metadata}"
   fi
 }

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -13,7 +13,7 @@ invoke_gradle() {
   fi
 
   args+=(--init-script "${INIT_SCRIPTS_DIR}/configure-gradle-enterprise.gradle")
-  args+=("-Dcom.gradle.enterprise.build_validation.build_number=${build_number}")
+  args+=("-Dcom.gradle.enterprise.build_validation.buildNumber=${build_number}")
 
   if [ "$enable_ge" == "on" ]; then
     args+=("-Dcom.gradle.enterprise.build_validation.gradle.plugin-repository.url=https://plugins.gradle.org/m2")

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 invoke_gradle() {
-  local args
+  local build_number args
   args=()
+  build_number=$1
+  shift
 
   local original_dir
   if [ -n "${project_dir}" ]; then
@@ -11,6 +13,7 @@ invoke_gradle() {
   fi
 
   args+=(--init-script "${INIT_SCRIPTS_DIR}/configure-gradle-enterprise.gradle")
+  args+=("-Dcom.gradle.enterprise.build_validation.build_number=${build_number}")
 
   if [ "$enable_ge" == "on" ]; then
     args+=("-Dcom.gradle.enterprise.build_validation.gradle.plugin-repository.url=https://plugins.gradle.org/m2")

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -30,7 +30,7 @@ debug() {
 }
 
 summary_row() {
-    infof "${SUMMARY_FMT}" "$1" "${2:-${WARN_COLOR}<unknown>${RESTORE}}"
+  infof "${SUMMARY_FMT}" "$1" "${2:-${WARN_COLOR}<unknown>${RESTORE}}"
 }
 
 comparison_summary_row() {
@@ -45,6 +45,26 @@ comparison_summary_row() {
   fi
 
   summary_row "${header}" "${value}"
+}
+
+quick_link_row() {
+  local header value unknown_tests unknown_values
+  header="$1"
+  shift
+  value="$1"
+  shift
+  unknown_tests=("$@")
+
+  mark_unknown=false
+  for v in "${unknown_tests[@]}"; do
+    [[ "$v" = "" ]] && mark_unknown=true
+  done
+
+  if [[ "${mark_unknown}" == "true" ]]; then
+    summary_row "${header}" ""
+  else
+    summary_row "${header}" "$value"
+  fi
 }
 
 print_bl() {
@@ -109,13 +129,14 @@ print_summary() {
 }
 
 print_experiment_info() {
-  comparison_summary_row "Project:" "${project_names[@]}"
-  comparison_summary_row "Git repo:" "${git_repos[@]}"
-  comparison_summary_row "Git branch:" "${git_branches[@]}"
-  comparison_summary_row "Git commit id:" "${git_commit_ids[@]}"
+  debug "git repo: 0=${git_repos[0]} 1=${git_repos[1]}"
+  comparison_summary_row "Project:" "${project_names[0]}" "${project_names[1]}"
+  comparison_summary_row "Git repo:" "${git_repos[0]}" "${git_repos[1]}"
+  comparison_summary_row "Git branch:" "${git_branches[0]}" "${git_branches[1]}"
+  comparison_summary_row "Git commit id:" "${git_commit_ids[0]}" "${git_commit_ids[1]}"
   summary_row "Git options:" "${git_options}"
   summary_row "Project dir:" "${project_dir:-<root directory>}"
-  comparison_summary_row "${BUILD_TOOL} ${BUILD_TOOL_TASK}s:" "${requested_tasks[@]}"
+  comparison_summary_row "${BUILD_TOOL} ${BUILD_TOOL_TASK}s:" "${requested_tasks[0]}" "${requested_tasks[1]}"
   summary_row "${BUILD_TOOL} arguments:" "${extra_args:-<none>}"
   summary_row "Experiment:" "${EXP_NO} ${EXP_NAME}"
   summary_row "Experiment id:" "${EXP_SCAN_TAG}"
@@ -271,25 +292,25 @@ print_quick_links() {
 print_gradle_quick_links() {
   info "Investigation Quick Links"
   info "-------------------------"
-  summary_row "Task execution overview:" "${base_urls[0]}/s/${build_scan_ids[1]}/performance/execution"
-  summary_row "Executed tasks timeline:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?outcome=success,failed&sort=longest"
-  summary_row "Avoided cacheable tasks:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?outcome=from-cache&sort=longest"
-  summary_row "Executed cacheable tasks:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&outcome=success,failed&sort=longest"
-  summary_row "Executed non-cacheable tasks:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?cacheability=any-non-cacheable,not:overlapping-outputs,not:validation-failure&outcome=success,failed&sort=longest"
-  summary_row "Build caching statistics:" "${base_urls[0]}/s/${build_scan_ids[1]}/performance/build-cache"
-  summary_row "Task inputs comparison:" "${base_urls[0]}/c/${build_scan_ids[0]}/${build_scan_ids[1]}/task-inputs?cacheability=cacheable"
+  quick_link_row "Task execution overview:" "${base_urls[1]}/s/${build_scan_ids[1]}/performance/execution" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Executed tasks timeline:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Avoided cacheable tasks:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?outcome=from-cache&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Executed cacheable tasks:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Executed non-cacheable tasks:" "${base_urls[1]}/s/${build_scan_ids[1]}/timeline?cacheability=any-non-cacheable,not:overlapping-outputs,not:validation-failure&outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Build caching statistics:" "${base_urls[1]}/s/${build_scan_ids[1]}/performance/build-cache" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Task inputs comparison:" "${base_urls[1]}/c/${build_scan_ids[0]}/${build_scan_ids[1]}/task-inputs?cacheability=cacheable" "${base_urls[1]}" "${build_scan_ids[0]}" "${build_scan_ids[1]}"
 }
 
 print_maven_quick_links() {
   info "Investigation Quick Links"
   info "-------------------------"
-  summary_row "Goal execution overview:" "${base_urls[0]}/s/${build_scan_ids[1]}/performance/execution"
-  summary_row "Executed goals timeline:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?outcome=success,failed&sort=longest"
-  summary_row "Avoided cacheable goals:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?outcome=from-cache&sort=longest"
-  summary_row "Executed cacheable goals:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?cacheability=cacheable&outcome=success,failed&sort=longest"
-  summary_row "Executed non-cacheable goals:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?cacheability=any-non-cacheable&outcome=success,failed&sort=longest"
-  summary_row "Build caching statistics:" "${base_urls[0]}/s/${build_scan_ids[1]}/performance/build-cache"
-  summary_row "Goal inputs comparison:" "${base_urls[0]}/c/${build_scan_ids[0]}/${build_scan_ids[1]}/goal-inputs?cacheability=cacheable"
+  quick_link_row "Goal execution overview:" "${base_urls[0]}/s/${build_scan_ids[1]}/performance/execution" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Executed goals timeline:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Avoided cacheable goals:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?outcome=from-cache&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Executed cacheable goals:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?cacheability=cacheable&outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Executed non-cacheable goals:" "${base_urls[0]}/s/${build_scan_ids[1]}/timeline?cacheability=any-non-cacheable&outcome=success,failed&sort=longest" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Build caching statistics:" "${base_urls[0]}/s/${build_scan_ids[1]}/performance/build-cache" "${base_urls[1]}" "${build_scan_ids[1]}"
+  quick_link_row "Goal inputs comparison:" "${base_urls[0]}/c/${build_scan_ids[0]}/${build_scan_ids[1]}/goal-inputs?cacheability=cacheable" "${base_urls[1]}" "${build_scan_ids[0]}" "${build_scan_ids[1]}"
 }
 
 max_length() {

--- a/components/scripts/lib/info.sh
+++ b/components/scripts/lib/info.sh
@@ -129,7 +129,6 @@ print_summary() {
 }
 
 print_experiment_info() {
-  debug "git repo: 0=${git_repos[0]} 1=${git_repos[1]}"
   comparison_summary_row "Project:" "${project_names[0]}" "${project_names[1]}"
   comparison_summary_row "Git repo:" "${git_repos[0]}" "${git_repos[1]}"
   comparison_summary_row "Git branch:" "${git_branches[0]}" "${git_branches[1]}"

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -54,7 +54,7 @@ invoke_maven() {
 
   args+=(
     -Dmaven.ext.class.path="${extension_classpath}"
-    -Dcom.gradle.enterprise.build_validation.build_number="${build_number}"
+    -Dcom.gradle.enterprise.build_validation.buildNumber="${build_number}"
     -Dcom.gradle.enterprise.build_validation.experimentDir="${EXP_DIR}"
     -Dcom.gradle.enterprise.build_validation.expId="${EXP_SCAN_TAG}"
     -Dcom.gradle.enterprise.build_validation.runId="${RUN_ID}"

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -11,8 +11,10 @@ find_maven_executable() {
 }
 
 invoke_maven() {
-  local args mvn
+  local build_number args mvn
   args=()
+  build_number=$1
+  shift
 
   local original_dir
   if [ -n "${project_dir}" ]; then
@@ -52,6 +54,7 @@ invoke_maven() {
 
   args+=(
     -Dmaven.ext.class.path="${extension_classpath}"
+    -Dcom.gradle.enterprise.build_validation.build_number="${build_number}"
     -Dcom.gradle.enterprise.build_validation.experimentDir="${EXP_DIR}"
     -Dcom.gradle.enterprise.build_validation.expId="${EXP_SCAN_TAG}"
     -Dcom.gradle.enterprise.build_validation.runId="${RUN_ID}"

--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -129,19 +129,23 @@ wizard_execute() {
 
 execute_first_build() {
   info "Running first build:"
-  execute_build
+  execute_build 0
 }
 
 execute_second_build() {
   info "Running second build:"
-  execute_build
+  execute_build 1
 }
 
 execute_build() {
+  local build_number
+  build_number="$1"
+  shift
+
   print_maven_command
 
   #shellcheck disable=SC2086  # we actually want ${tasks} to expand because it may have more than one maven goal
-  invoke_maven \
+  invoke_maven "${build_number}" \
      -Dgradle.cache.local.enabled=true \
      -Dgradle.cache.local.storeEnabled=true \
      -Dgradle.cache.remote.enabled=false \

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -132,20 +132,24 @@ wizard_execute() {
 
 execute_first_build() {
   info "Running first build:"
-  execute_build
+  execute_build 0
 }
 
 execute_second_build() {
   info "Running second build:"
   cd "${EXP_DIR}/second-build_${project_name}" || die "Unable to cd to ${EXP_DIR}/second-build_${project_name}"
-  execute_build
+  execute_build 1
 }
 
 execute_build() {
+  local build_number
+  build_number="$1"
+  shift
+
   print_maven_command
 
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
-  invoke_maven \
+  invoke_maven "${build_number}" \
      -Dgradle.cache.local.enabled=true \
      -Dgradle.cache.local.storeEnabled=true \
      -Dgradle.cache.remote.enabled=false \

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -115,31 +115,8 @@ validate_required_args() {
 }
 
 parse_build_scan_urls() {
-  # From https://stackoverflow.com/a/63993578/106189
-  # See also https://stackoverflow.com/a/45977232/106189
-  readonly URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?((/|$)([^?#]*))(\?([^#]*))?(#(.*))?$'
-  #                    ↑↑            ↑  ↑↑↑            ↑         ↑ ↑            ↑↑    ↑        ↑  ↑        ↑ ↑
-  #                    ||            |  |||            |         | |            ||    |        |  |        | |
-  #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       ||    12 rpath |  14 query | 16 fragment
-  #                    1 scheme:     |  |5 userinfo@             8 :...         ||             13 ?...     15 #...
-  #                                  |  4 authority                             |11 / or end-of-string
-  #                                  3  //...                                   10 path
-
-  local protocol ge_host port build_scan_id
-
-  for url in "${build_scan_urls[@]}"; do
-    if [[ "${url}" =~ $URI_REGEX ]]; then
-      protocol="${BASH_REMATCH[2]}"
-      ge_host="${BASH_REMATCH[7]}"
-      port="${BASH_REMATCH[8]}"
-      build_scan_id="$(basename "${BASH_REMATCH[10]}")"
-
-      base_urls+=("${protocol}://${ge_host}${port}")
-      build_scan_ids+=("$build_scan_id")
-    else
-      die "${url} is not a parsable URL." "${INVALID_INPUT}"
-    fi
-  done
+  parse_build_scan_url "${build_scan_urls[0]}" 0
+  parse_build_scan_url "${build_scan_urls[1]}" 1
 }
 
 fetch_build_scans() {

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -204,7 +204,7 @@ execute_build() {
   info "./mvnw -Dscan -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} clean ${tasks}$(print_extra_args)"
 
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
-  invoke_maven "${args[@]}"
+  invoke_maven 1 "${args[@]}"
 }
 
 # Overrides info.sh#print_experiment_specific_summary_info

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -148,6 +148,7 @@ validate_required_args() {
 }
 
 fetch_build_params_from_build_scan() {
+  parse_build_scan_url "${ci_build_scan_url}" 0
   fetch_and_read_build_scan_data all_data "${ci_build_scan_url}"
   read_build_params_from_build_scan_data
 }


### PR DESCRIPTION
Previously, the build validation scripts depended on the order build scans were
written to the build_scans.csv file, but this led to subtle and weird bugs,
particularly if the JVM running the build exits unexpectedly (such as in
response to an OutOfMemoryError).

This commit reworks things so that each row in the build_scans.csv file is
directly associated with the experiment build that generated it. When reading
build scan data, the association is re-established by matching build scan ids
with those that were produced by the builds.

A few other changes were made so that the build summary output makes sense,
particularly if the first build fails because the JVM exits unexpectedly.

Fixes #275
