### PR TITLE
Fix parsing of extra arguments for all platforms

### DIFF
--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -39,8 +39,8 @@ invoke_gradle() {
 
   # https://stackoverflow.com/a/31485948
   while IFS= read -r -d ''; do
-    args+=("$REPLY")
-  done < <( xargs printf '%s\0' <<< "$extra_args")
+    args+=( "$REPLY" )
+  done < <(xargs printf '%s\0' <<<"$extra_args")
 
   args+=("$@")
 

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -67,8 +67,8 @@ invoke_maven() {
 
   # https://stackoverflow.com/a/31485948
   while IFS= read -r -d ''; do
-    args+=("$REPLY")
-  done < <( xargs printf '%s\0' <<< "$extra_args")
+    args+=( "$REPLY" )
+  done < <(xargs printf '%s\0' <<<"$extra_args")
 
   args+=("$@")
 


### PR DESCRIPTION
This PR fixes the extra arguments parsing to be compatible on all tested platforms. You will notice that changes have only been made to whitespace. This change specifically uses the same whitespace as it appears on the referenced Stack Overflow post.

I tested these changes using the same command as was used in #305.

```shell
./01-validate-incremental-building.sh \
  -r https://github.com/gradle/common-custom-user-data-gradle-plugin \
  -t build \
  -a '--no-configuration-cache -Pfooo=barr -Pfoo=bar -Porg.gradle.jvmargs=-Xmx1g\ -XX:MaxMetaspaceSize=512m'
```

<img width="1497" alt="image" src="https://user-images.githubusercontent.com/5797900/223931345-59cf1b52-b669-43c1-8891-dfccb1c361ff.png">

See here for a successful cross-platform tests run: https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/4371353377