### PR TITLE
Empty array elements from additional arguments are no longer added to invocation arguments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+/gradlew        text eol=lf
 *.bat           text eol=crlf

--- a/.github/workflows/cross-platform-testing.yml
+++ b/.github/workflows/cross-platform-testing.yml
@@ -1,16 +1,11 @@
 name: Run Cross-Platform Tests
 
-on:
-  workflow_run:
-    workflows: [Create Development Release]
-    types: [completed]
-  workflow_dispatch:
+on: [ push ]
 
 jobs:
   cross_platform_tests:
     name: Test
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +34,7 @@ jobs:
         uses: Vampire/setup-wsl@v2
         with:
           distribution: Ubuntu-20.04
-          additional-packages: curl unzip wget apt-transport-https gnupg
+          additional-packages: curl unzip wget apt-transport-https gnupg autoconf
       - name: Set up JDK ${{ matrix.java-version }} on WSL
         if: ${{ runner.os == 'Windows' }}
         run: |
@@ -53,38 +48,40 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
-      - name: Download and extract build validation Scripts
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Build and extract build validation Scripts
         run: |
-          curl -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/development-latest/gradle-enterprise-gradle-build-validation-dev.zip
-          unzip -o gradle-enterprise-gradle-build-validation-*.zip
-          curl -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/development-latest/gradle-enterprise-maven-build-validation-dev.zip
-          unzip -o gradle-enterprise-maven-build-validation-*.zip
+          ./gradlew build
+          unzip -q -o build/distributions/gradle-enterprise-gradle-build-validation-dev.zip
+          unzip -q -o build/distributions/gradle-enterprise-maven-build-validation-dev.zip
       - name: Run Gradle Experiment 01
         run: |
           cd gradle-enterprise-gradle-build-validation
-          ./01-validate-incremental-building.sh -r https://github.com/etiennestuder/java-ordered-properties -t build -s https://ge.solutions-team.gradle.com
+          ./01-validate-incremental-building.sh -r https://github.com/etiennestuder/java-ordered-properties -t build -s https://ge.solutions-team.gradle.com --debug
       - name: Run Gradle Experiment 02
         run: |
           cd gradle-enterprise-gradle-build-validation
-          ./02-validate-local-build-caching-same-location.sh -r https://github.com/etiennestuder/java-ordered-properties -t build -s https://ge.solutions-team.gradle.com
+          ./02-validate-local-build-caching-same-location.sh -r https://github.com/etiennestuder/java-ordered-properties -t build -s https://ge.solutions-team.gradle.com --debug
       - name: Run Gradle Experiment 03
         run: |
           cd gradle-enterprise-gradle-build-validation
-          ./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties -t build -s https://ge.solutions-team.gradle.com
+          ./03-validate-local-build-caching-different-locations.sh -r https://github.com/etiennestuder/java-ordered-properties -t build -s https://ge.solutions-team.gradle.com --debug
       - name: Run Gradle Experiment 04
         run: |
           cd gradle-enterprise-gradle-build-validation
-          ./04-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/xildcv6frocau -2 https://ge.solutions-team.gradle.com/s/m5e7tyzedn562
+          ./04-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/xildcv6frocau -2 https://ge.solutions-team.gradle.com/s/m5e7tyzedn562 --debug
       - name: Run Maven Experiment 01
         run: |
           cd gradle-enterprise-maven-build-validation
-          ./01-validate-local-build-caching-same-location.sh -r https://github.com/gradle/maven-build-scan-quickstart.git -g test -s https://ge.solutions-team.gradle.com
+          ./01-validate-local-build-caching-same-location.sh -r https://github.com/gradle/maven-build-scan-quickstart.git -g test -s https://ge.solutions-team.gradle.com --debug
       - name: Run Maven Experiment 02
         run: |
           cd gradle-enterprise-maven-build-validation
-          ./02-validate-local-build-caching-different-locations.sh -r https://github.com/gradle/maven-build-scan-quickstart.git -g test -s https://ge.solutions-team.gradle.com
+          ./02-validate-local-build-caching-different-locations.sh -r https://github.com/gradle/maven-build-scan-quickstart.git -g test -s https://ge.solutions-team.gradle.com --debug
       - name: Run Maven Experiment 03
         run: |
           cd gradle-enterprise-maven-build-validation
-          ./03-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/oll3ve3wdv2t6 -2 https://ge.solutions-team.gradle.com/s/eaue4kvqnvnay
-
+          ./03-validate-remote-build-caching-ci-ci.sh -1 https://ge.solutions-team.gradle.com/s/oll3ve3wdv2t6 -2 https://ge.solutions-team.gradle.com/s/eaue4kvqnvnay --debug

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -39,7 +39,10 @@ invoke_gradle() {
 
   # https://stackoverflow.com/a/31485948
   while IFS= read -r -d ''; do
-    args+=( "$REPLY" )
+    local extra_arg="$REPLY"
+    if [ -n "$extra_arg" ]; then
+      args+=("$extra_arg")
+    fi
   done < <(xargs printf '%s\0' <<<"$extra_args")
 
   args+=("$@")

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -67,7 +67,10 @@ invoke_maven() {
 
   # https://stackoverflow.com/a/31485948
   while IFS= read -r -d ''; do
-    args+=( "$REPLY" )
+    local extra_arg="$REPLY"
+    if [ -n "$extra_arg" ]; then
+      args+=("$extra_arg")
+    fi
   done < <(xargs printf '%s\0' <<<"$extra_args")
 
   args+=("$@")


### PR DESCRIPTION
This is once again an attempt to address the failing cross platform tests. I tested this with the following command and also relied on the cross platform tests:

```
./01-validate-incremental-building.sh \
  -r https://github.com/gradle/common-custom-user-data-gradle-plugin \
  -t build \
  -a '--no-configuration-cache -Pfooo=barr -Pfoo=bar -Porg.gradle.jvmargs=-Xmx1g\ -XX:MaxMetaspaceSize=512m'
```