### PR TITLE
Workflows no longer run twice

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -1,6 +1,9 @@
 name: Verify Build
 
-on: [ pull_request, workflow_dispatch ]
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   verification:

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -1,11 +1,6 @@
 name: Verify Build
 
-on:
-  push:
-    branches-ignore:
-      - main
-  pull_request:
-  workflow_dispatch:
+on: [ pull_request, workflow_dispatch ]
 
 jobs:
   verification:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,6 @@
 name: Validate Gradle Wrapper
 
-on: [ push, pull_request, workflow_dispatch ]
+on: [ push, workflow_dispatch ]
 
 jobs:
   validation:


### PR DESCRIPTION
This PR updates the workflows so that:

- Build verification only runs on pull requests pointing to `main`.
- Gradle wrapper verification runs on every push (including to PR branches and `main`)

This aligns the workflow conditions with most of the GE Solutions repositories, with the exception of running build verification on pushes to main. Instead, this repository runs build verification as part of the development release. 