### PR TITLE
Fetch Build Scan data in parallel

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/ConsoleLogger.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/ConsoleLogger.java
@@ -5,7 +5,7 @@ import picocli.CommandLine;
 import java.io.PrintStream;
 
 public class ConsoleLogger {
-    
+
     private final PrintStream out;
     private final CommandLine.Help.ColorScheme colorScheme;
     private final boolean debugEnabled;
@@ -19,7 +19,7 @@ public class ConsoleLogger {
     }
 
     public void info(String message, Object... args) {
-        info(String.format(message + "%n", args));
+        info(String.format(message, args));
     }
 
     public void info(String message) {

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/ConsoleLogger.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/ConsoleLogger.java
@@ -27,15 +27,6 @@ public class ConsoleLogger {
         lastStatementIncludedNewline = true;
     }
 
-    public void infoNoNewline(String message) {
-        out.print(message);
-        lastStatementIncludedNewline = false;
-    }
-
-    public void debug(String message, Object... args) {
-        debug(String.format(message, args));
-    }
-
     public void debug(String message) {
         if (debugEnabled) {
             out.println(colorScheme.text("@|faint " + message + "|@"));

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildValidationDataCommand.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildValidationDataCommand.java
@@ -2,9 +2,9 @@ package com.gradle.enterprise.cli;
 
 import com.gradle.enterprise.api.client.FailedRequestException;
 import com.gradle.enterprise.api.client.GradleEnterpriseApiClient;
-import com.gradle.enterprise.model.NumberedBuildScan;
 import com.gradle.enterprise.model.BuildValidationData;
 import com.gradle.enterprise.model.CustomValueNames;
+import com.gradle.enterprise.model.NumberedBuildScan;
 import com.gradle.enterprise.network.NetworkSettingsConfigurator;
 import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine;
@@ -52,8 +52,6 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
     @Option(names = {"--brief-logging"}, description = "Only log a short message about fetching build scan data and when it completes.")
     private boolean briefLogging;
 
-    private boolean someScansFailedToFetch;
-
     @Override
     public Integer call() {
         // Use System.err for logging since we're going to write out the CSV to System.out
@@ -81,6 +79,7 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
     @NotNull
     private List<BuildValidationData> fetchBuildScanData(List<NumberedBuildScan> buildScans, CustomValueNames customValueKeys) {
         return buildScans.stream()
+            .parallel()
             .map(buildScan -> fetchBuildScanData(buildScan, customValueKeys))
             .collect(Collectors.toList());
     }
@@ -91,7 +90,7 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
             GradleEnterpriseApiClient apiClient = new GradleEnterpriseApiClient(buildScan.baseUrl(), customValueNames, logger);
             BuildValidationData data = apiClient.fetchBuildValidationData(buildScan);
 
-            logFinishedFetchingBuildScanData();
+            logFinishedFetchingBuildScanData(buildScan);
             return data;
         } catch (RuntimeException e) {
             logException(e);
@@ -113,7 +112,6 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
     }
 
     private void logException(RuntimeException e) {
-        someScansFailedToFetch = true;
         if (logger.isDebugEnabled()) {
             logger.error(e);
             if (e instanceof FailedRequestException) {
@@ -135,7 +133,7 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
 
     private void logStartFetchingAllBuildScanData() {
         if (briefLogging) {
-            logger.infoNoNewline("Fetching build scan data for all builds");
+            logger.info("Fetching Build Scan data for all builds");
             if (logger.isDebugEnabled()) {
                 logger.info("");
             }
@@ -144,30 +142,19 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
 
     private void logFinishedFetchingAllBuildScanData() {
         if (briefLogging) {
-            if (logger.isDebugEnabled() || someScansFailedToFetch) {
-                logger.info("done.");
-            } else {
-                logger.info(", done.");
-            }
+            logger.info("Finished fetching Build Scan data for all builds");
         }
     }
 
     private void logStartFetchingBuildScanData(NumberedBuildScan buildScan) {
         if (!briefLogging) {
-            logger.infoNoNewline(String.format("Fetching build scan data for the %s build", toOrdinal(buildScan.runNum())));
-            if (logger.isDebugEnabled()) {
-                logger.info("");
-            }
+            logger.info(String.format("Fetching Build Scan data for %s build", toOrdinal(buildScan.runNum())));
         }
     }
 
-    private void logFinishedFetchingBuildScanData() {
+    private void logFinishedFetchingBuildScanData(NumberedBuildScan buildScan) {
         if (!briefLogging) {
-            if (logger.isDebugEnabled() || someScansFailedToFetch) {
-                logger.info("done.");
-            } else {
-                logger.info(", done.");
-            }
+            logger.info(String.format("Finished fetching Build Scan data for %s build", toOrdinal(buildScan.runNum())));
         }
     }
 
@@ -185,8 +172,8 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
 
     private void logFetchResultFor(int runNum, String property, String customValueKey, boolean found) {
         logger.info(
-            "Looking up %s from custom value with name '%s' from the %s build scan, %s.",
-            property, customValueKey, toOrdinal(runNum), found ? "found": "not found"
+            "%s %s from custom value with name '%s' for %s build",
+            found ? "Found": "Did not find", property, customValueKey, toOrdinal(runNum)
         );
     }
 

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildValidationDataCommand.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildValidationDataCommand.java
@@ -134,9 +134,6 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
     private void logStartFetchingAllBuildScanData() {
         if (briefLogging) {
             logger.info("Fetching Build Scan data for all builds");
-            if (logger.isDebugEnabled()) {
-                logger.info("");
-            }
         }
     }
 
@@ -148,13 +145,13 @@ public class FetchBuildValidationDataCommand implements Callable<Integer> {
 
     private void logStartFetchingBuildScanData(NumberedBuildScan buildScan) {
         if (!briefLogging) {
-            logger.info(String.format("Fetching Build Scan data for %s build", toOrdinal(buildScan.runNum())));
+            logger.info("Fetching Build Scan data for %s build", toOrdinal(buildScan.runNum()));
         }
     }
 
     private void logFinishedFetchingBuildScanData(NumberedBuildScan buildScan) {
         if (!briefLogging) {
-            logger.info(String.format("Finished fetching Build Scan data for %s build", toOrdinal(buildScan.runNum())));
+            logger.info("Finished fetching Build Scan data for %s build", toOrdinal(buildScan.runNum()));
         }
     }
 

--- a/release/changes.md
+++ b/release/changes.md
@@ -4,6 +4,7 @@
 - [NEW] Construct more precise query parameters in links to timeline view in all experiment summaries
 - [NEW] Support `-x` command line option for Gradle experiment 1
 - [NEW] Add configuration settings to control the connect and read timeouts when fetching Build Scan data
+- [NEW] Fetch Build Scan data in parallel
 - [FIX] Incorrect parsing of additional argument values containing spaces
 - [FIX] Script does not list second build twice when first build fails
 


### PR DESCRIPTION
Some users have builds which produce a lot of Build Scan data, and so it can
sometimes take a while to fetch the data for all of the builds. Fetching the
Build Scan data in parallel provides a nice performance boost for such users.

In order to do this safely, the logging format needed to be adjusted and made
stateless (before we were tracking some state to provide a more concise log
output format).

Fixes #349
