### PR TITLE
Create a local readonly var instead of a global one

### DIFF
--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -97,7 +97,7 @@ parse_build_scan_csv() {
 parse_build_scan_url() {
   # From https://stackoverflow.com/a/63993578/106189
   # See also https://stackoverflow.com/a/45977232/106189
-  readonly URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?((/|$)([^?#]*))(\?([^#]*))?(#(.*))?$'
+  local -r URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?((/|$)([^?#]*))(\?([^#]*))?(#(.*))?$'
   #                    ↑↑            ↑  ↑↑↑            ↑         ↑ ↑            ↑↑    ↑        ↑  ↑        ↑ ↑
   #                    ||            |  |||            |         | |            ||    |        |  |        | |
   #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       ||    12 rpath |  14 query | 16 fragment


### PR DESCRIPTION
readonly always creates a global (readonly) variable. Doing this in a function
makes it likely an error message will be displayed because of repeated attempts
to redefine the same read-only global variable.
