### PR TITLE
Experiments end early if Build Scan is not published

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -96,7 +96,7 @@ def registerBuildScanActions = { def buildScan ->
 
     def errorFile = new File(expDir, 'errors.txt')
     buildScan.onError { error ->
-        errorFile.text = error
+        errorFile.text = 'Build Scan publishing failed.'
     }
 }
 

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -32,6 +32,18 @@ read_build_scan_metadata() {
   fi
 }
 
+is_build_scan_metadata_missing() {
+  if [ ! -f "${BUILD_SCAN_FILE}" ]; then
+    return 0
+  fi
+  while IFS=, read -r run_num field_1 field_2 field_3; do
+    if [[ "$run_num" == "$1"  ]]; then
+      return 1
+    fi
+  done < "${BUILD_SCAN_FILE}"
+  return 0
+}
+
 fetch_and_read_build_scan_data() {
   local build_cache_metrics_only="$1"
   shift

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -64,6 +64,11 @@ invoke_gradle() {
     die "ERROR: The experiment cannot continue because of a non-recoverable failure while running the build: $(cat "${EXP_DIR}/errors.txt")"
   fi
 
+  if is_build_scan_metadata_missing "$run_num"; then
+    print_bl
+    die "ERROR: The experiment cannot continue because a Build Scan was not published."
+  fi
+
   # defined in git.sh
   read_git_metadata_from_current_repo
   requested_tasks+=("${tasks}")

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -84,6 +84,11 @@ invoke_maven() {
     build_outcomes+=("FAILED")
   fi
 
+  if is_build_scan_metadata_missing "$run_num"; then
+    print_bl
+    die "ERROR: The experiment cannot continue because of a non-recoverable failure while running the build."
+  fi
+
   # defined in git.sh
   read_git_metadata_from_current_repo
   requested_tasks+=("${tasks}")


### PR DESCRIPTION
This PR adds a condition to the Gradle and Maven invocation to end the experiment early if a Build Scan was not published for a build.