### PR TITLE
Fix Gradle Experiment 5 and Maven Experiment 4 to pass the 1st build scan URL to the fetch utility

### DIFF
--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -54,7 +54,6 @@ execute() {
   print_bl
   validate_required_args
 
-  parse_build_scan_urls
   fetch_build_scans
   make_experiment_dir
 
@@ -95,7 +94,6 @@ wizard_execute() {
   explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
-  parse_build_scan_urls
   fetch_build_scans
   make_experiment_dir
 
@@ -114,11 +112,6 @@ validate_required_args() {
   fi
   build_scan_urls+=("${_arg_first_build_ci}")
   build_scan_urls+=("${_arg_second_build_ci}")
-}
-
-parse_build_scan_urls() {
-  parse_build_scan_url "${build_scan_urls[0]}" 0
-  parse_build_scan_url "${build_scan_urls[1]}" 1
 }
 
 fetch_build_scans() {

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -150,7 +150,7 @@ validate_required_args() {
 }
 
 fetch_build_params_from_build_scan() {
-  parse_build_scan_url "${ci_build_scan_url}" 0
+  build_scan_urls+=( "${ci_build_scan_url}" )
   fetch_and_read_build_scan_data all_data "${ci_build_scan_url}"
   read_build_params_from_build_scan_data
 }

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -59,6 +59,7 @@ parse_build_scan_csv() {
 
     debug "Build Scan $field_4 is for build $run_num"
     project_names[run_num]="$field_1"
+    build_scan_ids[run_num]="$field_4"
 
     if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
       base_urls[run_num]="$field_2"
@@ -92,34 +93,6 @@ parse_build_scan_csv() {
   instant_savings_build_time="$(calculate_instant_savings_build_time)"
   pending_savings="$(calculate_pending_savings)"
   pending_savings_build_time="$(calculate_pending_savings_build_time)"
-}
-
-parse_build_scan_url() {
-  # From https://stackoverflow.com/a/63993578/106189
-  # See also https://stackoverflow.com/a/45977232/106189
-  local -r URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?((/|$)([^?#]*))(\?([^#]*))?(#(.*))?$'
-  #                    ↑↑            ↑  ↑↑↑            ↑         ↑ ↑            ↑↑    ↑        ↑  ↑        ↑ ↑
-  #                    ||            |  |||            |         | |            ||    |        |  |        | |
-  #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       ||    12 rpath |  14 query | 16 fragment
-  #                    1 scheme:     |  |5 userinfo@             8 :...         ||             13 ?...     15 #...
-  #                                  |  4 authority                             |11 / or end-of-string
-  #                                  3  //...                                   10 path
-
-  local build_scan_url run_num protocol ge_host port build_scan_id
-  build_scan_url="$1"
-  run_num="$2"
-
-  if [[ "${build_scan_url}" =~ $URI_REGEX ]]; then
-    protocol="${BASH_REMATCH[2]}"
-    ge_host="${BASH_REMATCH[7]}"
-    port="${BASH_REMATCH[8]}"
-    build_scan_id="$(basename "${BASH_REMATCH[10]}")"
-
-    base_urls[run_num]="${protocol}://${ge_host}${port}"
-    build_scan_ids[run_num]="$build_scan_id"
-  else
-    die "${build_scan_url} is not a parsable URL." "${INVALID_INPUT}"
-  fi
 }
 
 # The initial_build_time is the build time of the first build.

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -52,7 +52,6 @@ execute() {
   print_bl
   validate_required_args
 
-  parse_build_scan_urls
   fetch_build_scans
   make_experiment_dir
 
@@ -93,7 +92,6 @@ wizard_execute() {
   explain_command_to_repeat_experiment_after_collecting_parameters
 
   print_bl
-  parse_build_scan_urls
   fetch_build_scans
   make_experiment_dir
 
@@ -112,11 +110,6 @@ validate_required_args() {
   fi
   build_scan_urls+=("${_arg_first_build_ci}")
   build_scan_urls+=("${_arg_second_build_ci}")
-}
-
-parse_build_scan_urls() {
-  parse_build_scan_url "${build_scan_urls[0]}" 0
-  parse_build_scan_url "${build_scan_urls[1]}" 1
 }
 
 fetch_build_scans() {

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -148,7 +148,7 @@ validate_required_args() {
 }
 
 fetch_build_params_from_build_scan() {
-  parse_build_scan_url "${ci_build_scan_url}" 0
+  build_scan_urls+=( "${ci_build_scan_url}" )
   fetch_and_read_build_scan_data all_data "${ci_build_scan_url}"
   read_build_params_from_build_scan_data
 }


### PR DESCRIPTION
This commit also removes the parse_build_scan_url function because it turns out
it is not needed anymore.
