### PR TITLE
Experiments can be run with parallel GC enabled on older Gradle versions

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -12,7 +12,7 @@ initscript {
 
     def getInputParam = { String name ->
         def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-        return System.getProperty(name) ?: System.getenv(envVarName)
+        return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
     }
 
     def pluginRepositoryUrl = getInputParam('com.gradle.enterprise.build-validation.gradle.plugin-repository.url')
@@ -61,7 +61,7 @@ if (!isTopLevelBuild) {
 
 def getInputParam = { String name ->
     def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def geUrl = getInputParam('com.gradle.enterprise.build-validation.gradle-enterprise.url')

--- a/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
@@ -5,7 +5,7 @@ if (!isTopLevelBuild) {
 
 def getInputParam = { String name ->
     def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def expDir = getInputParam('com.gradle.enterprise.build-validation.expDir')

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -5,7 +5,7 @@ if (!isTopLevelBuild) {
 
 def getInputParam = { String name ->
     def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def remoteBuildCacheUrl = getInputParam('com.gradle.enterprise.build-validation.remoteBuildCacheUrl')


### PR DESCRIPTION
## Context

### What is the issue?

Given a Gradle version older than 7.1, when `-XX:+UseParallelGC` is included as a JVM argument to the Gradle daemon, then user provided system properties from the command line are not available in certain parts of an Initialization script.

### Who is impacted?

Any projects which are on a version of Gradle older than 7.1 and are supplying the JVM argument `-XX:+UseParallelGC` to the Gradle daemon. This can be done by setting the `org.gradle.jvmargs` property in `gradle.properties`.

```properties
org.gradle.jvmargs="-XX:+UseParallelGC"
```

### What changed between 2.2.1 and 2.3 to cause this regression?

In 2.3, it was decided to migrate all initialization script configuration to system properties. Previously, the configuration was a mix of system properties and project properties. The change was made to be consistent with the TeamCity initialization scripts, with itself, and also be compatible with the [`org.gradlex.build-parameters`](https://github.com/gradlex-org/build-parameters) plugin which fails the build on unknown project properties. 

### Is it only system properties that are unavailable?

Yes, but only when accessed via `System.getProperty(..)`. User provided system properties are still accessible via `gradle.startParameter.systemPropertiesArgs.get(..)`. Environment variables accessed via `System.getenv(..)` and project properties accessed via `gradle.startParameter.projectProperties.get(..)` are also available.

### Is there any other important context to understand for reviewers?

I was unable to find a Gradle Build Tool bug report for this issue. Considering that this issue is not present in Gradle 7.1, it is likely to have been fixed by this change, possibly unintentionally: https://github.com/gradle/gradle/pull/16757

## Investigation

I put together a reproducer project to help understand affected Gradle versions and to discover what exactly is available and where. Shown below is a summary of my findings.

| 3.0 to 8.0.2            | `System.getProperty(..)` | `systemPropertiesArgs.get(..)` | `System.getenv(..)` | `projectProperties.get(..)` |
|-------------------------|--------------------------|-----------------------------------------------|---------------------|--------------------------------------------|
| `initscript { }`        | ✔️                       | ✔️                                            | ✔️                  | ✔️                                         | 
| script root             | ✔️                       | ✔️                                            | ✔️                  | ✔️                                         | 
| `settingsEvaluated { }` | ✔️                       | ✔️                                            | ✔️                  | ✔️                                         |

| 3.0 to 7.0.2</br>XX:+UseParallelGC | `System.getProperty(..)` | `systemPropertiesArgs.get(..)` | `System.getenv(..)` | `projectProperties.get(..)` |
|-----------------------------------|--------------------------|-----------------------------------------------|---------------------|--------------------------------------------|
| `initscript { }`                  | ❌️                       | ✔️                                            | ✔️                  | ✔️                                         | 
| script root                       | ❌️                       | ✔️                                            | ✔️                  | ✔️                                         | 
| `settingsEvaluated { }`           | ✔️                       | ✔️                                            | ✔️                  | ✔️                                         |

| 7.1 to 8.0.2</br>XX:+UseParallelGC | `System.getProperty(..)` | `systemPropertiesArgs.get(..)` | `System.getenv(..)` | `projectProperties.get(..)` |
|------------------------------------|--------------------------|--------------------------------|---------------------|-----------------------------|
| `initscript { }`                   | ✔️                       | ✔️                             | ✔️                  | ✔️                          | 
| script root                        | ✔️                       | ✔️                             | ✔️                  | ✔️                          | 
| `settingsEvaluated { }`            | ✔️                       | ✔️                             | ✔️                  | ✔️                          |

## Solution

As a solution, I have chosen to replace all usages of `System.getProperty(..)` with `gradle.startParameter.systemPropertiesArgs[name]` because it requires very minimal changes to the initialization scripts and no changes to the validation shell scripts. It also will not break the [`org.gradlex.build-parameters`](https://github.com/gradlex-org/build-parameters) plugin.

It should be noted that this works because these system properties only exist to make the initialization scripts configurable from the shell scripts via command line arguments. This would not work for reading system properties in all use cases (e.g. reading system properties from gradle.properties). This fix will work for the build validation scripts use case, but we should be cautious about where else we apply it.
