### PR TITLE
Experiments can be run with parallel GC enabled and configuration cache is not invalidated between runs

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -12,7 +12,7 @@ initscript {
 
     def getInputParam = { String name ->
         def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-        return System.getProperty(name) ?: System.getenv(envVarName)
+        return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
     }
 
     def pluginRepositoryUrl = getInputParam('com.gradle.enterprise.build-validation.gradle.plugin-repository.url')
@@ -61,7 +61,7 @@ if (!isTopLevelBuild) {
 
 def getInputParam = { String name ->
     def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def geUrl = getInputParam('com.gradle.enterprise.build-validation.gradle-enterprise.url')

--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -72,7 +72,6 @@ def ccudPluginVersion = getInputParam('com.gradle.enterprise.build-validation.cc
 def expDir = getInputParam('com.gradle.enterprise.build-validation.expDir')
 def expId = getInputParam('com.gradle.enterprise.build-validation.expId')
 def runId = getInputParam('com.gradle.enterprise.build-validation.runId')
-def runNum = getInputParam('com.gradle.enterprise.build-validation.runNum')
 def scriptsVersion = getInputParam('com.gradle.enterprise.build-validation.scriptsVersion')
 
 def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
@@ -87,6 +86,11 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
 def registerBuildScanActions = { def buildScan ->
     def scanFile = new File(expDir, 'build-scans.csv')
     buildScan.buildScanPublished { publishedBuildScan ->
+        def getInputParamCompatibleWithCC = { String name ->
+            def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+            return System.getProperty(name) ?: System.getenv(envVarName)
+        }
+        def runNum = getInputParamCompatibleWithCC('com.gradle.enterprise.build-validation.runNum')
         def buildScanUri = publishedBuildScan.buildScanUri
         def buildScanId = publishedBuildScan.buildScanId
         def port = (buildScanUri.port != -1) ? ':' + buildScanUri.port : ''

--- a/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
@@ -5,7 +5,7 @@ if (!isTopLevelBuild) {
 
 def getInputParam = { String name ->
     def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def expDir = getInputParam('com.gradle.enterprise.build-validation.expDir')

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -5,7 +5,7 @@ if (!isTopLevelBuild) {
 
 def getInputParam = { String name ->
     def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def remoteBuildCacheUrl = getInputParam('com.gradle.enterprise.build-validation.remoteBuildCacheUrl')


### PR DESCRIPTION
This PR is a second attempt at PR #361. It's description is still entirely valid. 

However, it introduced new issue for projects using configuration caching. It was since reverted from `main`.

This PR solves the original issue in a way that is compatible with configuration caching. 