### PR TITLE
Do not require Gradle Enterprise server URL when Build Scan publishing is disabled

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -274,7 +274,7 @@ static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
 
 static void addCustomValueAndSearchLink(buildScan, String label, String value) {
     buildScan.value(label, value)
-    if (buildScan.metaClass.respondsTo(buildScan, 'getServer')) { // required for Gradle 4.x / build-scan-plugin 1.16
+    if (buildScan.metaClass.respondsTo(buildScan, 'getServer') && buildScan.server) { // required for Gradle 4.x / build-scan-plugin 1.16
         String server = buildScan.server
         String searchParams = "search.names=" + urlEncode(label) + "&search.values=" + urlEncode(value)
         String url = appendIfMissing(server, "/") + "scans?" + searchParams + "#selection.buildScanB=" + urlEncode("{SCAN_ID}")

--- a/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-gradle-enterprise.gradle
@@ -81,6 +81,7 @@ def expDir = getInputParam('com.gradle.enterprise.build-validation.expDir')
 def expId = getInputParam('com.gradle.enterprise.build-validation.expId')
 def runId = getInputParam('com.gradle.enterprise.build-validation.runId')
 def scriptsVersion = getInputParam('com.gradle.enterprise.build-validation.scriptsVersion')
+def omitServerUrlValidation = Boolean.parseBoolean(getInputParam('com.gradle.enterprise.build-validation.omitServerUrlValidation'))
 
 def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
@@ -202,7 +203,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (geUrl) buildScan.server = geUrl
                 if (geAllowUntrustedServer) buildScan.allowUntrustedServer = geAllowUntrustedServer
 
-                if (!buildScan.server) {
+                if (!buildScan.server && !omitServerUrlValidation) {
                     logErrorMissingGradleEnterpriseServerURL()
                     throw new IllegalStateException("The Gradle Enterprise server URL is not configured.\n" +
                             "Either configure it directly (see https://docs.gradle.com/enterprise/gradle-plugin/#gradle_5_x_2) in the project,\n" +
@@ -251,7 +252,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             if (geUrl) ext.server = geUrl
             if (geAllowUntrustedServer) ext.allowUntrustedServer = geAllowUntrustedServer
 
-            if (!ext.server) {
+            if (!ext.server && !omitServerUrlValidation) {
                 logErrorMissingGradleEnterpriseServerURL()
                 throw new IllegalStateException("The Gradle Enterprise server URL is not configured.\n" +
                         "Either configure it directly (see https://docs.gradle.com/enterprise/gradle-plugin/#gradle_6_x_and_later_2) in the project,\n" +

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -23,6 +23,8 @@ invoke_gradle() {
   if [ -n "${ge_server}" ]; then
     args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.url=${ge_server}")
     args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.allow-untrusted-server=false")
+  elif [ "$build_scan_publishing_mode" == "off" ]; then
+    args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.url=https://0.0.0.0")
   fi
 
   if [[ "${build_scan_publishing_mode}" == "off" ]]; then

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -23,11 +23,10 @@ invoke_gradle() {
   if [ -n "${ge_server}" ]; then
     args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.url=${ge_server}")
     args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.allow-untrusted-server=false")
-  elif [ "$build_scan_publishing_mode" == "off" ]; then
-    args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.url=https://0.0.0.0")
   fi
 
   if [[ "${build_scan_publishing_mode}" == "off" ]]; then
+    args+=("-Dcom.gradle.enterprise.build-validation.omitServerUrlValidation=true")
     args+=("-Dscan.dump")
   fi
 


### PR DESCRIPTION
This PR adds back functionality that existed in previous versions of the build validation scripts (`2.2.1` and `2.2.0`) to not require a server URL to be configured when running with the `-x` / `--disable-build-scan-publishing`.

https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/v2.2.1/components/scripts/lib/gradle.sh#L22-L24