### PR TITLE
Interactive mode requires `-s` when `-e` is used

### DIFF
--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -54,7 +54,7 @@ main() {
 
 execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   make_experiment_dir
   git_checkout_project "build_${project_name}"
@@ -76,7 +76,7 @@ execute() {
 
 wizard_execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   print_introduction
 

--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -76,6 +76,8 @@ execute() {
 
 wizard_execute() {
   print_bl
+  validate_required_config
+
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -361,5 +361,5 @@ EOF
   echo -n "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/gradle/01-validate-incremental-building.sh
+++ b/components/scripts/gradle/01-validate-incremental-building.sh
@@ -53,9 +53,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   make_experiment_dir
   git_checkout_project "build_${project_name}"
 
@@ -75,9 +72,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
-  validate_required_args
-
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -341,5 +341,5 @@ EOF
   echo -n "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -77,6 +77,8 @@ execute() {
 
 wizard_execute() {
   print_bl
+  validate_required_config
+
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -54,7 +54,7 @@ main() {
 
 execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   make_experiment_dir
   make_local_cache_dir
@@ -77,7 +77,7 @@ execute() {
 
 wizard_execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   print_introduction
 

--- a/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
+++ b/components/scripts/gradle/02-validate-local-build-caching-same-location.sh
@@ -53,9 +53,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   make_experiment_dir
   make_local_cache_dir
   git_checkout_project "build_${project_name}"
@@ -76,9 +73,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
-  validate_required_args
-
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -380,5 +380,5 @@ EOF
 }
 
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -53,9 +53,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   make_experiment_dir
   make_local_cache_dir
   git_checkout_project "first-build_${project_name}"
@@ -77,9 +74,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
-  validate_required_args
-
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -78,6 +78,8 @@ execute() {
 
 wizard_execute() {
   print_bl
+  validate_required_config
+
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/gradle/03-validate-local-build-caching-different-locations.sh
@@ -54,7 +54,7 @@ main() {
 
 execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   make_experiment_dir
   make_local_cache_dir
@@ -78,7 +78,7 @@ execute() {
 
 wizard_execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   print_introduction
 

--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -318,5 +318,5 @@ EOF
   print_interactive_text "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -103,6 +103,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
+# Overrides config.sh#validate_required_args
 validate_required_args() {
   if [ -z "${_arg_first_build_ci}" ]; then
     _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"

--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -51,9 +51,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   fetch_build_scans
   make_experiment_dir
 
@@ -62,7 +59,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
   print_introduction
 
   print_bl
@@ -105,16 +101,18 @@ wizard_execute() {
 
 # Overrides config.sh#validate_required_args
 validate_required_args() {
-  if [ -z "${_arg_first_build_ci}" ]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
-  fi
+  if [ "${interactive_mode}" == "off" ]; then
+    if [ -z "${_arg_first_build_ci}" ]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
+    fi
 
-  if [ -z "${_arg_second_build_ci}" ]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument: --second-build-ci" "${INVALID_INPUT}"
-  fi
+    if [ -z "${_arg_second_build_ci}" ]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument: --second-build-ci" "${INVALID_INPUT}"
+    fi
 
-  build_scan_urls+=("${_arg_first_build_ci}")
-  build_scan_urls+=("${_arg_second_build_ci}")
+    build_scan_urls+=("${_arg_first_build_ci}")
+    build_scan_urls+=("${_arg_second_build_ci}")
+  fi
 }
 
 fetch_build_scans() {

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -133,7 +133,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
-map_additional_script_arguments() {
+map_additional_script_args() {
   ci_build_scan_url="${_arg_first_build_ci}"
   remote_build_cache_url="${_arg_remote_build_cache_url}"
   mapping_file="${_arg_mapping_file}"
@@ -512,5 +512,5 @@ EOF
   print_interactive_text "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -54,9 +54,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   fetch_build_params_from_build_scan
   validate_build_config
 
@@ -75,9 +72,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
-  validate_required_args
-
   print_introduction
 
   print_bl

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -75,6 +75,8 @@ execute() {
 
 wizard_execute() {
   print_bl
+  validate_required_args
+
   print_introduction
 
   print_bl
@@ -144,8 +146,14 @@ process_script_arguments() {
 }
 
 validate_required_args() {
-  if [ -z "${ci_build_scan_url}" ]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
+  if [ "${interactive_mode}" == "off" ]; then
+    if [ -z "${ci_build_scan_url}" ]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
+    fi
+  fi
+
+  if [[ "${enable_ge}" == "on" && -z "${ge_server}" ]]; then
+    _PRINT_HELP=yes die "ERROR: Missing required argument when enabling Gradle Enterprise on a project not already connected: --gradle-enterprise-server" "${INVALID_INPUT}"
   fi
 }
 
@@ -186,10 +194,6 @@ validate_build_config() {
 
   if [ -z "${git_commit_id}" ]; then
     _PRINT_HELP=yes die "ERROR: Git commit id was not found in the build scan. Specify missing argument: --git-commit-id" "${INVALID_INPUT}"
-  fi
-
-  if [[ "${enable_ge}" == "on" && -z "${ge_server}" ]]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument when enabling Gradle Enterprise on a project not already connected: --gradle-enterprise-server" "${INVALID_INPUT}"
   fi
 }
 

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -43,7 +43,6 @@ remote_build_cache_url=''
 mapping_file=''
 
 main() {
-  process_script_arguments
   if [ "${interactive_mode}" == "on" ]; then
     wizard_execute
   else
@@ -134,7 +133,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
-process_script_arguments() {
+process_additional_script_arguments() {
   ci_build_scan_url="${_arg_first_build_ci}"
   remote_build_cache_url="${_arg_remote_build_cache_url}"
   mapping_file="${_arg_mapping_file}"

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -145,6 +145,7 @@ process_script_arguments() {
   mapping_file="${_arg_mapping_file}"
 }
 
+# Overrides config.sh#validate_required_args
 validate_required_args() {
   if [ "${interactive_mode}" == "off" ]; then
     if [ -z "${ci_build_scan_url}" ]; then

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -56,6 +56,7 @@ main() {
 execute() {
   print_bl
   validate_required_args
+
   fetch_build_params_from_build_scan
   validate_build_config
 

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -133,7 +133,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
-process_additional_script_arguments() {
+map_additional_script_arguments() {
   ci_build_scan_url="${_arg_first_build_ci}"
   remote_build_cache_url="${_arg_remote_build_cache_url}"
   mapping_file="${_arg_mapping_file}"

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -75,9 +75,9 @@ process_arguments() {
   fi
 }
 
-validate_required_config() {
-  # In non-interactive mode, these properties are required.
-  # In interactive mode, the user will be prompted to enter any missing details.
+validate_required_args() {
+  # In non-interactive mode, these arguments are required.
+  # In interactive mode, the user will be prompted to enter any missing config.
   if [ "${interactive_mode}" == "off" ]; then
     if [ -z "${git_repo}" ]; then
       _PRINT_HELP=yes die "ERROR: Missing required argument: --git-repo" "${INVALID_INPUT}"

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -74,8 +74,16 @@ process_arguments() {
     debug_mode="${_arg_debug}"
   fi
 
+  process_additional_script_arguments
+
   print_bl
   validate_required_args
+}
+
+# Some experiments may require additional arguments to be processed, in which
+# case this function should be overridden for that experiment.
+process_additional_script_arguments() {
+  true
 }
 
 # This function performs common validation relevant for most experiments.

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-process_arguments() {
+process_args() {
   parse_commandline "$@"
-  map_common_script_arguments
-  map_additional_script_arguments
+  map_common_script_args
+  map_additional_script_args
   print_bl
   validate_required_args
 }
 
-map_common_script_arguments() {
+map_common_script_args() {
   if [ -n "${_arg_git_repo+x}" ]; then
     git_repo="${_arg_git_repo}"
     project_name="$(basename -s .git "${git_repo}")"
@@ -78,7 +78,7 @@ map_common_script_arguments() {
 
 # Some experiments may require additional arguments, in which case this function
 # should be overridden for that experiment.
-map_additional_script_arguments() {
+map_additional_script_args() {
   true
 }
 

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -74,6 +74,7 @@ process_arguments() {
     debug_mode="${_arg_debug}"
   fi
 
+  print_bl
   validate_required_args
 }
 

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC2034 # not all of the variables set in this function are used by all scripts
 process_arguments() {
   parse_commandline "$@"
+  map_common_script_arguments
+  map_additional_script_arguments
+  print_bl
+  validate_required_args
+}
 
+map_common_script_arguments() {
   if [ -n "${_arg_git_repo+x}" ]; then
     git_repo="${_arg_git_repo}"
     project_name="$(basename -s .git "${git_repo}")"
@@ -25,13 +30,11 @@ process_arguments() {
     project_dir="${_arg_project_dir}"
   fi
 
-  # shellcheck disable=SC2154
   if [ -n "${_arg_tasks+x}" ]; then
     tasks="${_arg_tasks}"
     remove_clean_from_tasks
   fi
 
-  # shellcheck disable=SC2154
   if [ -n "${_arg_goals+x}" ]; then
     tasks="${_arg_goals}"
     remove_clean_from_tasks
@@ -41,7 +44,6 @@ process_arguments() {
     extra_args="${_arg_args}"
   fi
 
-  #shellcheck disable=SC2154
   if [ -n "${_arg_mapping_file+x}" ]; then
     mapping_file="${_arg_mapping_file}"
   fi
@@ -50,7 +52,6 @@ process_arguments() {
     ge_server="${_arg_gradle_enterprise_server}"
   fi
 
-  #shellcheck disable=SC2154
   if [ -n "${_arg_enable_gradle_enterprise+x}" ]; then
     enable_ge="${_arg_enable_gradle_enterprise}"
   fi
@@ -73,16 +74,11 @@ process_arguments() {
   if [ -n "${_arg_debug+x}" ]; then
     debug_mode="${_arg_debug}"
   fi
-
-  process_additional_script_arguments
-
-  print_bl
-  validate_required_args
 }
 
-# Some experiments may require additional arguments to be processed, in which
-# case this function should be overridden for that experiment.
-process_additional_script_arguments() {
+# Some experiments may require additional arguments, in which case this function
+# should be overridden for that experiment.
+map_additional_script_arguments() {
   true
 }
 

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -73,8 +73,13 @@ process_arguments() {
   if [ -n "${_arg_debug+x}" ]; then
     debug_mode="${_arg_debug}"
   fi
+
+  validate_required_args
 }
 
+# This function performs common validation relevant for most experiments.
+# Some experiments may have a different set of required arguments, in which case
+# this function should be overridden for that experiment.
 validate_required_args() {
   # In non-interactive mode, these arguments are required.
   # In interactive mode, the user will be prompted to enter any missing config.

--- a/components/scripts/lib/config.sh
+++ b/components/scripts/lib/config.sh
@@ -76,15 +76,19 @@ process_arguments() {
 }
 
 validate_required_config() {
-  if [ -z "${git_repo}" ]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument: --git-repo" "${INVALID_INPUT}"
-  fi
+  # In non-interactive mode, these properties are required.
+  # In interactive mode, the user will be prompted to enter any missing details.
+  if [ "${interactive_mode}" == "off" ]; then
+    if [ -z "${git_repo}" ]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument: --git-repo" "${INVALID_INPUT}"
+    fi
 
-  if [ -z "${tasks}" ]; then
-    if [[ "${BUILD_TOOL}" == "Maven" ]]; then
-      _PRINT_HELP=yes die "ERROR: Missing required argument: --goals" "${INVALID_INPUT}"
-    else
-      _PRINT_HELP=yes die "ERROR: Missing required argument: --tasks" "${INVALID_INPUT}"
+    if [ -z "${tasks}" ]; then
+      if [[ "${BUILD_TOOL}" == "Maven" ]]; then
+        _PRINT_HELP=yes die "ERROR: Missing required argument: --goals" "${INVALID_INPUT}"
+      else
+        _PRINT_HELP=yes die "ERROR: Missing required argument: --tasks" "${INVALID_INPUT}"
+      fi
     fi
   fi
 

--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -76,6 +76,8 @@ execute() {
 
 wizard_execute() {
   print_bl
+  validate_required_config
+
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -53,7 +53,7 @@ main() {
 
 execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   make_experiment_dir
   make_local_cache_dir
@@ -76,7 +76,7 @@ execute() {
 
 wizard_execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   print_introduction
 

--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -52,9 +52,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   make_experiment_dir
   make_local_cache_dir
   git_checkout_project "build_${project_name}"
@@ -75,9 +72,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
-  validate_required_args
-
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -342,5 +342,5 @@ EOF
   echo -n "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -52,9 +52,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   make_experiment_dir
   make_local_cache_dir
   git_checkout_project "first-build_${project_name}"
@@ -75,9 +72,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
-  validate_required_args
-
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -76,6 +76,8 @@ execute() {
 
 wizard_execute() {
   print_bl
+  validate_required_config
+
   print_introduction
 
   if [[ "${build_scan_publishing_mode}" == "on" ]]; then

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -53,7 +53,7 @@ main() {
 
 execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   make_experiment_dir
   make_local_cache_dir
@@ -76,7 +76,7 @@ execute() {
 
 wizard_execute() {
   print_bl
-  validate_required_config
+  validate_required_args
 
   print_introduction
 

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -378,5 +378,5 @@ EOF
   echo -n "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -101,6 +101,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
+# Overrides config.sh#validate_required_args
 validate_required_args() {
   if [ -z "${_arg_first_build_ci}" ]; then
     _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -316,5 +316,5 @@ EOF
   print_interactive_text "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -49,9 +49,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   fetch_build_scans
   make_experiment_dir
 
@@ -60,7 +57,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
   print_introduction
 
   print_bl
@@ -103,16 +99,18 @@ wizard_execute() {
 
 # Overrides config.sh#validate_required_args
 validate_required_args() {
-  if [ -z "${_arg_first_build_ci}" ]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
-  fi
+  if [ "${interactive_mode}" == "off" ]; then
+    if [ -z "${_arg_first_build_ci}" ]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
+    fi
 
-  if [ -z "${_arg_second_build_ci}" ]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument: --second-build-ci" "${INVALID_INPUT}"
-  fi
+    if [ -z "${_arg_second_build_ci}" ]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument: --second-build-ci" "${INVALID_INPUT}"
+    fi
 
-  build_scan_urls+=("${_arg_first_build_ci}")
-  build_scan_urls+=("${_arg_second_build_ci}")
+    build_scan_urls+=("${_arg_first_build_ci}")
+    build_scan_urls+=("${_arg_second_build_ci}")
+  fi
 }
 
 fetch_build_scans() {

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -143,6 +143,7 @@ process_script_arguments() {
   mapping_file="${_arg_mapping_file}"
 }
 
+# Overrides config.sh#validate_required_args
 validate_required_args() {
   if [ "${interactive_mode}" == "off" ]; then
     if [ -z "${ci_build_scan_url}" ]; then

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -73,6 +73,8 @@ execute() {
 
 wizard_execute() {
   print_bl
+  validate_required_args
+
   print_introduction
 
   print_bl
@@ -142,8 +144,14 @@ process_script_arguments() {
 }
 
 validate_required_args() {
-  if [ -z "${ci_build_scan_url}" ]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
+  if [ "${interactive_mode}" == "off" ]; then
+    if [ -z "${ci_build_scan_url}" ]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument: --first-build-ci" "${INVALID_INPUT}"
+    fi
+  fi
+
+  if [[ "${enable_ge}" == "on" && -z "${ge_server}" ]]; then
+      _PRINT_HELP=yes die "ERROR: Missing required argument when enabling Gradle Enterprise on a project not already connected: --gradle-enterprise-server" "${INVALID_INPUT}"
   fi
 }
 
@@ -184,10 +192,6 @@ validate_build_config() {
 
   if [ -z "${git_commit_id}" ]; then
     _PRINT_HELP=yes die "ERROR: Git commit id was not found in the build scan. Specify missing argument: --git-commit-id" "${INVALID_INPUT}"
-  fi
-
-  if [[ "${enable_ge}" == "on" && -z "${ge_server}" ]]; then
-    _PRINT_HELP=yes die "ERROR: Missing required argument when enabling Gradle Enterprise on a project not already connected: --gradle-enterprise-server" "${INVALID_INPUT}"
   fi
 }
 

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -131,7 +131,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
-map_additional_script_arguments() {
+map_additional_script_args() {
   ci_build_scan_url="${_arg_first_build_ci}"
   remote_build_cache_url="${_arg_remote_build_cache_url}"
   mapping_file="${_arg_mapping_file}"
@@ -519,5 +519,5 @@ EOF
   print_interactive_text "${text}"
 }
 
-process_arguments "$@"
+process_args "$@"
 main

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -41,7 +41,6 @@ remote_build_cache_url=''
 mapping_file=''
 
 main() {
-  process_script_arguments
   if [ "${interactive_mode}" == "on" ]; then
     wizard_execute
   else
@@ -132,7 +131,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
-process_script_arguments() {
+process_additional_script_arguments() {
   ci_build_scan_url="${_arg_first_build_ci}"
   remote_build_cache_url="${_arg_remote_build_cache_url}"
   mapping_file="${_arg_mapping_file}"

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -54,6 +54,7 @@ main() {
 execute() {
   print_bl
   validate_required_args
+
   fetch_build_params_from_build_scan
   validate_build_config
 

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -131,7 +131,7 @@ wizard_execute() {
   explain_and_print_summary
 }
 
-process_additional_script_arguments() {
+map_additional_script_arguments() {
   ci_build_scan_url="${_arg_first_build_ci}"
   remote_build_cache_url="${_arg_remote_build_cache_url}"
   mapping_file="${_arg_mapping_file}"
@@ -146,7 +146,7 @@ validate_required_args() {
   fi
 
   if [[ "${enable_ge}" == "on" && -z "${ge_server}" ]]; then
-      _PRINT_HELP=yes die "ERROR: Missing required argument when enabling Gradle Enterprise on a project not already connected: --gradle-enterprise-server" "${INVALID_INPUT}"
+    _PRINT_HELP=yes die "ERROR: Missing required argument when enabling Gradle Enterprise on a project not already connected: --gradle-enterprise-server" "${INVALID_INPUT}"
   fi
 }
 

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -52,9 +52,6 @@ main() {
 }
 
 execute() {
-  print_bl
-  validate_required_args
-
   fetch_build_params_from_build_scan
   validate_build_config
 
@@ -73,9 +70,6 @@ execute() {
 }
 
 wizard_execute() {
-  print_bl
-  validate_required_args
-
   print_introduction
 
   print_bl

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,3 @@
-- [NEW] TBD
+- [FIX] Experiments may end up publishing to scans.gradle.com if insufficient options are provided
+- [FIX] Using `-e` without `-s` in interactive mode gives poor error message
+- [FIX] Error messages are inconsistent


### PR DESCRIPTION
This PR adds validation for interactive mode to require `-s` when `e` is used. This brings consistency to how the scripts already work for non-interactive mode.

Previously, the experiments would fail with the error that a Gradle Enterprise server was not defined. 

This check only applies to Gradle 1-3 and Maven 1-2.

To test these changes, I ran all of the below experiments and verified all of them failed immediately. 

```
./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/gradle/8.x/no-ge -t 'build' -i -e
./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/gradle/8.x/no-ge -t 'build' -e
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/gradle/8.x/no-ge -t 'build' -i -e
./02-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/gradle/8.x/no-ge -t 'build' -e
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/gradle/8.x/no-ge -t 'build' -i -e
./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/gradle/8.x/no-ge -t 'build' -e

./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/maven/3.9.x/no-ge -g 'verify' -i -e
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/maven/3.9.x/no-ge -g 'verify' -e
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/maven/3.9.x/no-ge -g 'verify' -i -e
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -b no-tool -p sample-projects/maven/3.9.x/no-ge -g 'verify' -e

./01-validate-incremental-building.sh -r git@github.com:gradle/ge-solutions.git

./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/ge-solutions.git
```