### PR TITLE
Performance characteristics includes the serialization factors of both builds

### DIFF
--- a/components/scripts/lib/summary.sh
+++ b/components/scripts/lib/summary.sh
@@ -282,8 +282,10 @@ print_executed_non_cacheable_tasks() {
 
 print_serialization_factor() {
   local value
-  if [[ -n "${serialization_factors[0]}" ]]; then
-    value="$(to_two_decimal_places "${serialization_factors[0]}")x"
+  if [[ -n "${serialization_factors[0]}" && -n "${serialization_factors[1]}" ]]; then
+    printf -v value "%sx first build, %sx second build" \
+      "$(to_two_decimal_places "${serialization_factors[0]}")" \
+      "$(to_two_decimal_places "${serialization_factors[1]}")"
   fi
   summary_row "Serialization factor:" "${value}"
 }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- [NEW] TBD
+- Performance characteristics includes the serialization factors of both builds


### PR DESCRIPTION
This PR updates the serialization factor row in the performance characteristics summary to include the serialization factor from both builds. For example:

![image](https://user-images.githubusercontent.com/5797900/228016515-fad62be5-3ad3-42b7-bf82-8ee3f42db332.png)