### PR TITLE
New function name is used for offline processing

### DIFF
--- a/components/scripts/lib/build-scan-offline.sh
+++ b/components/scripts/lib/build-scan-offline.sh
@@ -35,8 +35,10 @@ find_build_scan_dump() {
 
 read_build_scan_dumps() {
   local build_scan_data
+
   echo -n "Extracting build scan data"
   build_scan_data="$(invoke_java "$BUILD_SCAN_SUPPORT_TOOL_JAR" extract "0,${build_scan_dumps[0]}"  "1,${build_scan_dumps[1]}")"
-  parse_build_scan_data "build_cache_metrics_only" "$build_scan_data"
   echo ", done."
+
+  parse_build_scans_and_build_time_metrics "build_cache_metrics_only" "$build_scan_data"
 }

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -50,11 +50,6 @@ fetch_single_build_scan() {
   local build_scan_data
   build_scan_data="$(fetch_build_scan_data brief_logging "${build_scan_url}")"
 
-  debug "Raw build scan data"
-  debug "---------------------------"
-  debug "${build_scan_data}"
-  debug ""
-
   parse_single_build_scan "${build_scan_data}"
 }
 
@@ -71,11 +66,6 @@ fetch_build_scans_and_build_time_metrics() {
 
   local build_scan_data
   build_scan_data="$(fetch_build_scan_data "${brief_logging}" "${build_scan_urls[@]}")"
-
-  debug "Raw build scan data"
-  debug "---------------------------"
-  debug "${build_scan_data}"
-  debug ""
 
   parse_build_scans_and_build_time_metrics "${build_cache_metrics_only}" "${build_scan_data}"
 }

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -36,6 +36,8 @@ serialization_factors=()
 parse_single_build_scan() {
   local build_scan_data="$1"
 
+  debug_build_scan_data "$build_scan_data"
+
   local build_scan_rows
   IFS=$'\n' read -rd '' -a build_scan_rows <<< "$build_scan_data"
 
@@ -46,6 +48,8 @@ parse_build_scans_and_build_time_metrics() {
   local build_cache_metrics_only="$1"
   local build_scan_data="$2"
 
+  debug_build_scan_data "$build_scan_data"
+
   local build_scan_rows
   IFS=$'\n' read -rd '' -a build_scan_rows <<< "$build_scan_data"
 
@@ -53,6 +57,15 @@ parse_build_scans_and_build_time_metrics() {
   parse_build_scan_row "${build_cache_metrics_only}" "${build_scan_rows[2]}"
 
   parse_build_time_metrics "${build_scan_rows[4]}"
+}
+
+debug_build_scan_data() {
+  local build_scan_data="$1"
+
+  debug "Raw build scan data"
+  debug "---------------------------"
+  debug "${build_scan_data}"
+  debug ""
 }
 
 # shellcheck disable=SC2034 # not all scripts use all of the fetched data


### PR DESCRIPTION
An occurrence of the old `parse_build_scan_data` function name was still referenced in the offline processing flow. This PR updates it to use the new function `parse_build_scans_and_build_time_metrics`.

This change also consolidates the debug logging for printing build validation data to `build-scan-parse.sh`, where it used to be. Otherwise the same 4 lines would have to be duplicated to the offline flow as well. 