### PR TITLE
Scripts code is explained and more consistent

### DIFF
--- a/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/gradle/04-validate-remote-build-caching-ci-ci.sh
@@ -116,7 +116,7 @@ validate_required_args() {
 }
 
 fetch_build_scans() {
-  fetch_build_scans_and_build_time_metrics all_data "${build_scan_urls[@]}"
+  fetch_build_scans_and_build_time_metrics 'all_data' "${build_scan_urls[@]}"
 }
 
 # Overrides summary.sh#print_experiment_specific_summary_info

--- a/components/scripts/lib/build-scan-offline.sh
+++ b/components/scripts/lib/build-scan-offline.sh
@@ -40,5 +40,5 @@ read_build_scan_dumps() {
   build_scan_data="$(invoke_java "$BUILD_SCAN_SUPPORT_TOOL_JAR" extract "0,${build_scan_dumps[0]}"  "1,${build_scan_dumps[1]}")"
   echo ", done."
 
-  parse_build_scans_and_build_time_metrics "build_cache_metrics_only" "$build_scan_data"
+  parse_build_scans_and_build_time_metrics 'build_cache_metrics_only' "$build_scan_data"
 }

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -7,7 +7,7 @@ readonly FETCH_BUILD_SCAN_DATA_JAR="${LIB_DIR}/export-api-clients/fetch-build-sc
 # Enterprise API.
 process_build_scan_data_online() {
   read_build_scan_metadata
-  fetch_build_scans_and_build_time_metrics build_cache_metrics_only "${build_scan_urls[@]}"
+  fetch_build_scans_and_build_time_metrics 'build_cache_metrics_only' "${build_scan_urls[@]}"
 }
 
 read_build_scan_metadata() {
@@ -59,7 +59,7 @@ fetch_build_scans_and_build_time_metrics() {
   local build_scan_urls=("$@")
 
   local brief_logging
-  if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
+  if [[ "$build_cache_metrics_only" != 'build_cache_metrics_only' ]]; then
     brief_logging="brief_logging"
     info "Fetching build scan data"
   fi

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -39,6 +39,8 @@ parse_single_build_scan() {
   debug_build_scan_data "$build_scan_data"
 
   local build_scan_rows
+
+  # Parses build scan data to an array by line
   IFS=$'\n' read -rd '' -a build_scan_rows <<< "$build_scan_data"
 
   parse_build_scan_row all_data "${build_scan_rows[1]}"
@@ -51,6 +53,8 @@ parse_build_scans_and_build_time_metrics() {
   debug_build_scan_data "$build_scan_data"
 
   local build_scan_rows
+
+  # Parses build scan data to an array by line
   IFS=$'\n' read -rd '' -a build_scan_rows <<< "$build_scan_data"
 
   parse_build_scan_row "${build_cache_metrics_only}" "${build_scan_rows[1]}"

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -115,11 +115,6 @@ parse_build_scan_row() {
 parse_build_time_metrics() {
   local build_time_metrics_row="$1"
 
-  while IFS=, read -r field_1 field_2 field_3 field_4 field_5; do
-    initial_build_time="$field_1"
-    instant_savings="$field_2"
-    instant_savings_build_time="$field_3"
-    pending_savings="$field_4"
-    pending_savings_build_time="$field_5"
-  done <<< "${build_time_metrics_row}"
+  # Parses each build time metric to the corresponding global variable
+  IFS=, read -r initial_build_time instant_savings instant_savings_build_time pending_savings pending_savings_build_time <<< "${build_time_metrics_row}"
 }

--- a/components/scripts/lib/build-scan-parse.sh
+++ b/components/scripts/lib/build-scan-parse.sh
@@ -43,7 +43,7 @@ parse_single_build_scan() {
   # Parses build scan data to an array by line
   IFS=$'\n' read -rd '' -a build_scan_rows <<< "$build_scan_data"
 
-  parse_build_scan_row all_data "${build_scan_rows[1]}"
+  parse_build_scan_row 'all_data' "${build_scan_rows[1]}"
 }
 
 parse_build_scans_and_build_time_metrics() {
@@ -84,7 +84,7 @@ parse_build_scan_row() {
     project_names[run_num]="$field_1"
     build_scan_ids[run_num]="$field_4"
 
-    if [[ "$build_cache_metrics_only" != "build_cache_metrics_only" ]]; then
+    if [[ "$build_cache_metrics_only" != 'build_cache_metrics_only' ]]; then
       base_urls[run_num]="$field_2"
       build_scan_urls[run_num]="$field_3"
       git_repos[run_num]="$field_5"

--- a/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
+++ b/components/scripts/maven/03-validate-remote-build-caching-ci-ci.sh
@@ -114,7 +114,7 @@ validate_required_args() {
 }
 
 fetch_build_scans() {
-  fetch_build_scans_and_build_time_metrics all_data "${build_scan_urls[@]}"
+  fetch_build_scans_and_build_time_metrics 'all_data' "${build_scan_urls[@]}"
 }
 
 # Overrides summary.sh#print_experiment_specific_summary_info


### PR DESCRIPTION
This PR makes several very minor improvements to the scripts code. These suggestions were from @jthurne on https://github.com/gradle/gradle-enterprise-build-validation-scripts/pull/383 but the PR had already been merged. 

This PR:
- f3bf09b54193585d3e8af716a9021322d2b22efa Adds a comment to the command used to parse Build Scan data by line
- b626997da7d0583007cb6bbec0dc6a00b0e683fd Makes all occurrences of `build_cache_metrics_only` and `all_data` consistently use single quotes
- 3a13ef32ff3fb4ab1b68a5666504efbfe4af3521 Greatly simplifies the parsing of build time metrics

I recommend reviewing each commit one at a time.