### PR TITLE
Logging level when fetching Build Scan data from Gradle Enterprise is incorrect

### DIFF
--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -48,7 +48,7 @@ fetch_single_build_scan() {
   local build_scan_url="$1"
 
   local build_scan_data
-  build_scan_data="$(fetch_build_scan_data verbose_logging "${build_scan_url}")"
+  build_scan_data="$(fetch_build_scan_data 'verbose_logging' "${build_scan_url}")"
 
   parse_single_build_scan "${build_scan_data}"
 }

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -59,8 +59,9 @@ fetch_build_scans_and_build_time_metrics() {
   local build_scan_urls=("$@")
 
   local brief_logging
-  if [[ "$build_cache_metrics_only" != 'build_cache_metrics_only' ]]; then
+  if [[ "${build_cache_metrics_only}" == 'build_cache_metrics_only' ]]; then
     brief_logging="brief_logging"
+  else
     info "Fetching build scan data"
   fi
 

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -48,7 +48,7 @@ fetch_single_build_scan() {
   local build_scan_url="$1"
 
   local build_scan_data
-  build_scan_data="$(fetch_build_scan_data brief_logging "${build_scan_url}")"
+  build_scan_data="$(fetch_build_scan_data verbose_logging "${build_scan_url}")"
 
   parse_single_build_scan "${build_scan_data}"
 }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- [NEW] TBD
+- [FIX] Logging level when fetching Build Scan data from Gradle Enterprise is incorrect 


### PR DESCRIPTION
This change fixes a regression introduced by #383 where the conditions under which `--brief-logging` were incorrectly switched.

**Behavior in v2.3.2 (correct)**

![image](https://user-images.githubusercontent.com/5797900/231326025-e6d28bee-afbc-4205-afd4-8d44455f74e2.png)

**Behavior in v2.3.3 (incorrect)**

![image](https://user-images.githubusercontent.com/5797900/231326092-0f5d1534-5507-4940-8304-78171b6316d8.png)

**Behavior with these changes (correct)**

![image](https://user-images.githubusercontent.com/5797900/231326204-6684c327-b868-4340-b9ed-f6462706a14f.png)
