### PR TITLE
Build Scan URL parsing is more resilient 

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/model/NumberedBuildScan.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/model/NumberedBuildScan.java
@@ -65,10 +65,10 @@ public class NumberedBuildScan {
 
     private static String extractBuildScanId(URL buildScanUrl) {
         String[] pathSegments = buildScanUrl.getPath().split("/");
-        if (pathSegments.length == 0) {
+        if (pathSegments.length <= 2 || !pathSegments[1].equals("s")) {
             throw new IllegalArgumentException("Invalid Build Scan URL: " + buildScanUrl);
         }
-        return pathSegments[pathSegments.length - 1];
+        return pathSegments[2];
     }
 
     private static URL toURL(String url) {

--- a/components/fetch-build-scan-data-cmdline-tool/src/test/java/com/gradle/enterprise/model/NumberedBuildScanTests.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/test/java/com/gradle/enterprise/model/NumberedBuildScanTests.java
@@ -1,0 +1,42 @@
+package com.gradle.enterprise.model;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NumberedBuildScanTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://ge.example.com/s/7slcdesxr2xnw",
+            "https://ge.example.com/s/7slcdesxr2xnw/",
+            "https://ge.example.com/s/7slcdesxr2xnw/timeline",
+            "https://ge.example.com/s/7slcdesxr2xnw/console-log?page=1",
+            "https://ge.example.com/s/7slcdesxr2xnw/projects#:foo-service"
+    })
+    void validBuildScanUrlsAreCorrectlyParsed(String buildScanUrl) {
+        final NumberedBuildScan numberedBuildScan = NumberedBuildScan.parse("0," + buildScanUrl);
+        assertAll(
+                () -> assertEquals(new URL("https://ge.example.com"), numberedBuildScan.baseUrl()),
+                () -> assertEquals("7slcdesxr2xnw", numberedBuildScan.buildScanId())
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://ge.example.com",
+            "https://ge.example.com/",
+            "https://ge.example.com/s",
+            "https://ge.example.com/s/",
+            "https://ge.example.com/S/",
+            "https://ge.example.com/S/7slcdesxr2xnw",
+    })
+    void invalidBuildScanUrlsThrowException(String buildScanUrl) {
+        assertThrows(IllegalArgumentException.class, () -> NumberedBuildScan.parse("0," + buildScanUrl));
+    }
+}

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
 - [FIX] Logging level when fetching Build Scan data from Gradle Enterprise is incorrect 
+- [FIX] Experiments accepting Build Scan URLs incorrectly parse Build Scan ID when path contains extra parts


### PR DESCRIPTION
This PR makes the Build Scan URL parsing logic much more resilient.

Previously, given a Build Scan URL with additional path parts after the ID, then parsing would fail. For example:

```
./04-validate-remote-build-caching-ci-ci.sh \
  -1 https://e.grdev.net/s/meiwdomvrhneo/timeline \
  -2 https://e.grdev.net/s/7fmkhoppnrpre/projects#:admin-database
```

This would result in:

![image](https://user-images.githubusercontent.com/5797900/231519306-5c4e5cce-c263-4e8d-8295-f384316da2bc.png)

![image](https://user-images.githubusercontent.com/5797900/231519368-355096fa-932d-4c7f-9410-33844b5704b8.png)

Now, the same command results in a successful experiment and investigation quick links:

![image](https://user-images.githubusercontent.com/5797900/231519524-32baeb14-4303-4efa-ab0a-fe184feaba72.png)

![image](https://user-images.githubusercontent.com/5797900/231519646-7ed620d6-670c-4f2a-9ec4-b585e6fd52b1.png)
