### PR TITLE
Use Provider API to read version.txt and changes.md files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,11 @@ repositories {
     mavenCentral()
 }
 
-val appVersion = layout.projectDirectory.file("release/version.txt").asFile.readText().trim()
+val releaseVersion = releaseVersion()
+val releaseNotes = releaseNotes()
+
 allprojects {
-    version = appVersion
+    version = releaseVersion
 }
 
 val argbash by configurations.creating
@@ -93,8 +95,10 @@ val copyGradleScripts by tasks.registering(Copy::class) {
     group = "build"
     description = "Copies the Gradle source and generated scripts to output directory."
 
-    val projectVersion = appVersion // local variable required for configuration cache compatibility
-    inputs.property("project.version", projectVersion)
+    // local variable required for configuration cache compatibility
+    // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:not_yet_implemented:accessing_top_level_at_execution
+    val releaseVersion = releaseVersion
+    inputs.property("project.version", releaseVersion)
 
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
@@ -102,7 +106,7 @@ val copyGradleScripts by tasks.registering(Copy::class) {
 
     from(layout.projectDirectory.dir("components/scripts/gradle")) {
         exclude("gradle-init-scripts")
-        filter { line: String -> line.replace("<HEAD>", projectVersion) }
+        filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
     }
     from(layout.projectDirectory.dir("components/scripts/gradle")) {
         include("gradle-init-scripts/**")
@@ -114,7 +118,7 @@ val copyGradleScripts by tasks.registering(Copy::class) {
         include("network.settings")
         include("lib/**")
         exclude("lib/cli-parsers")
-        filter { line: String -> line.replace("<HEAD>", projectVersion) }
+        filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
     }
     from(generateBashCliParsers.map { it.outputDir.file("lib/cli-parsers/gradle") }) {
         into("lib/")
@@ -129,15 +133,17 @@ val copyMavenScripts by tasks.registering(Copy::class) {
     group = "build"
     description = "Copies the Maven source and generated scripts to output directory."
 
-    val projectVersion = appVersion // local variable required for configuration cache compatibility
-    inputs.property("project.version", projectVersion)
+    // local variable required for configuration cache compatibility
+    // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:not_yet_implemented:accessing_top_level_at_execution
+    val releaseVersion = releaseVersion
+    inputs.property("project.version", releaseVersion)
 
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
     rename("version.txt", "VERSION")
 
     from(layout.projectDirectory.dir("components/scripts/maven")) {
-        filter { line: String -> line.replace("<HEAD>", projectVersion) }
+        filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
     }
     from(layout.projectDirectory.dir("components/scripts/")) {
         include("README.md")
@@ -145,7 +151,7 @@ val copyMavenScripts by tasks.registering(Copy::class) {
         include("network.settings")
         include("lib/**")
         exclude("lib/cli-parsers")
-        filter { line: String -> line.replace("<HEAD>", projectVersion) }
+        filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
     }
     from(generateBashCliParsers.map { it.outputDir.file("lib/cli-parsers/maven") }) {
         into("lib/")
@@ -169,7 +175,7 @@ val assembleGradleScripts by tasks.registering(Zip::class) {
     group = "build"
     description = "Packages the Gradle experiment scripts in a zip archive."
     archiveBaseName.set("gradle-enterprise-gradle-build-validation")
-    archiveFileName.set("${archiveBaseName.get()}-${distributionVersion()}.zip")
+    archiveFileName.set("${archiveBaseName.get()}-${distributionVersion().get()}.zip")
     from(copyGradleScripts)
     into(archiveBaseName.get())
 }
@@ -178,7 +184,7 @@ val assembleMavenScripts by tasks.registering(Zip::class) {
     group = "build"
     description = "Packages the Maven experiment scripts in a zip archive."
     archiveBaseName.set("gradle-enterprise-maven-build-validation")
-    archiveFileName.set("${archiveBaseName.get()}-${distributionVersion()}.zip")
+    archiveFileName.set("${archiveBaseName.get()}-${distributionVersion().get()}.zip")
     from(copyMavenScripts)
     into(archiveBaseName.get())
 }
@@ -253,7 +259,7 @@ githubRelease {
     prerelease.set(isDevelopmentRelease)
     overwrite.set(isDevelopmentRelease)
     generateReleaseNotes.set(false)
-    body.set(layout.projectDirectory.file("release/changes.md").asFile.readText().trim())
+    body.set(releaseNotes)
     releaseAssets(assembleGradleScripts, assembleMavenScripts, generateChecksums.map { it.outputs.files.asFileTree })
 }
 
@@ -272,26 +278,24 @@ tasks.withType(Sign::class).configureEach {
     notCompatibleWithConfigurationCache("$name task does not support configuration caching")
 }
 
-fun gitHubReleaseName(): String {
-    if (isDevelopmentRelease) {
-        return "Development Build"
-    } else {
-        return version.toString()
-    }
+fun gitHubReleaseName(): Provider<String> {
+    return releaseVersion.map { if (isDevelopmentRelease) "Development release" else it }
 }
 
-fun gitReleaseTag(): String {
-    if (isDevelopmentRelease) {
-        return "development-latest"
-    } else {
-        return "v${version}"
-    }
+fun gitReleaseTag(): Provider<String> {
+    return releaseVersion.map { if (isDevelopmentRelease) "development-latest" else "v$it" }
 }
 
-fun distributionVersion(): String {
-    if (isDevelopmentRelease) {
-        return "dev"
-    } else {
-        return version.toString()
-    }
+fun distributionVersion(): Provider<String> {
+    return releaseVersion.map { if (isDevelopmentRelease) "dev" else it }
+}
+
+fun releaseVersion(): Provider<String> {
+    val versionFile = layout.projectDirectory.file("release/version.txt")
+    return providers.fileContents(versionFile).asText.map { it.trim() }
+}
+
+fun releaseNotes(): Provider<String> {
+    val releaseNotesFile = layout.projectDirectory.file("release/changes.md")
+    return providers.fileContents(releaseNotesFile).asText.map { it.trim() }
 }


### PR DESCRIPTION
* Add release notes to githubRelease body
* Use Provider.fileContents() to read `changes.md` and `version.txt` files

### Tests

Execute `./gradlew githubRelease` with `dryRun.set(true)`

```
:githubRelease [This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed.]
:githubRelease [CHECKING FOR PREVIOUS RELEASE]
:githubRelease [EXISTING RELEASE FOUND https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/tag/development-latest]
:githubRelease [DELETING RELEASE Development Build]
:githubRelease [CREATING NEW RELEASE 
{
    tag_name               = development-latest
    target_commitish       = main
    name                   = Development release
    generate_release_notes = false
    body                   = 
        - [FIX] Logging level when fetching Build Scan data from Gradle Enterprise is incorrect 
                - [FIX] Experiments accepting Build Scan URLs incorrectly parse Build Scan ID when path contains extra parts
    draft                  = false
    prerelease             = true
}]
```

And with `finalRelease` property set...

```
:githubRelease [This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed.]
:githubRelease [CHECKING FOR PREVIOUS RELEASE]
:githubRelease [CREATING NEW RELEASE 
{
    tag_name               = v2.3.4
    target_commitish       = main
    name                   = 2.3.4
    generate_release_notes = false
    body                   = 
        - [FIX] Logging level when fetching Build Scan data from Gradle Enterprise is incorrect 
                - [FIX] Experiments accepting Build Scan URLs incorrectly parse Build Scan ID when path contains extra parts
    draft                  = false
    prerelease             = false
}]
```

### Configuration Cache Compatibility

Modifying `version.txt` results in a new configuration cache entry being stored, and the dry run `githubRelease` uses the updated version.

Modifying `changes.md` results in a new configuration cache entry being stored, and the dry run `githubRelease` uses the updated body.

Running with no changes results in the configuration cache entry being re-used.