### PR TITLE
Get tagName from githubRelease extension

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -266,7 +266,7 @@ githubRelease {
 val createReleaseTag by tasks.registering(CreateGitTag::class) {
     // Ensure tag is created only after a successful build
     mustRunAfter("build")
-    tagName.set(gitReleaseTag())
+    tagName.set(githubRelease.tagName.map { it.toString() })
     overwriteExisting.set(isDevelopmentRelease)
 }
 


### PR DESCRIPTION
Keeping consistent with other repositories, get `tagName` from `githubRelease` extension when configuring `createReleaseTag` task.

### Tests

***`createReleaseTag` - pushing the tag to the remote repository was disabled when executing these tests***

1. Execute `createReleaseTag` with `finalRelease` property set, and verify tag was properly created
```bash
gradle-enterprise-build-validation-scripts % git tag -l v2.3.6
gradle-enterprise-build-validation-scripts % ./gradlew -q clean createReleaseTag -PfinalRelease
gradle-enterprise-build-validation-scripts % git tag -l v2.3.6
v2.3.6
```
2. Execute `createReleaseTag` without `finalRelease` property set, and verify tag was properly created
```bash
tyler@tyler-mbp gradle-enterprise-build-validation-scripts % git tag -l development-latest
tyler@tyler-mbp gradle-enterprise-build-validation-scripts % ./gradlew -q clean createReleaseTag
tyler@tyler-mbp gradle-enterprise-build-validation-scripts % git tag -l development-latest
development-latest
```