### PR TITLE
Allow configuration cache assertions to support multiple build runs

### DIFF
--- a/.github/actions/gradle/experiment-config-cache/action.yml
+++ b/.github/actions/gradle/experiment-config-cache/action.yml
@@ -28,5 +28,5 @@ runs:
       shell: bash
     - name: Validate Gradle Configuration Cache compatibility
       run: exit 3
-      if: steps.run.outputs.configCacheStored != '1' || steps.run.outputs.configCacheReused != '1'
+      if: steps.run.outputs.configCacheReused == '0' || steps.run.outputs.configCacheStored != steps.run.outputs.configCacheReused
       shell: bash


### PR DESCRIPTION
The experiment-config-cache GH action is not supporting multiple build experiment runs as we are looking explicitly for [one single execution](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/9f93fa0ea247622b2e2375f322647502fd8e34bd/.github/actions/gradle/experiment-config-cache/action.yml#L31).

This PR fixes https://github.com/gradle/gradle-enterprise-build-validation-scripts/issues/429
