### PR TITLE
Add support for CLIENT_JAVA_HOME

### DIFF
--- a/Gradle.md
+++ b/Gradle.md
@@ -18,7 +18,7 @@ The build validation scripts are compatible with a large range of Gradle version
 
 | Build Validation Scripts version | Compatible Gradle versions | Compatible Gradle Enterprise versions |
 |----------------------------------|----------------------------|---------------------------------------|
-| 2.0+                             | 5.0+                       | 2022.1+                               |  
+| 2.0+                             | 5.0+                       | 2022.1+                               |
 | 1.0 - 1.0.2                      | 5.0+                       | 2021.2+                               |
 
 ## Installation
@@ -86,7 +86,7 @@ is invoked, as shown in the example below.
 
 The scripts return with an exit code that depends on the outcome of running a given experiment.
 
-| Exit Code | Reason                                                                                                 | 
+| Exit Code | Reason                                                                                                 |
 |-----------|--------------------------------------------------------------------------------------------------------|
 | 0         | The experiment completed successfully                                                                  |
 | 1         | An invalid input was provided while attempting to run the experiment                                   |
@@ -153,13 +153,25 @@ Gradle Enterprise server at ge.example.io.
 ## Running the experiments without publishing build scans
 
 The scripts that run all builds locally can be configured to not publish any build scans and instead extract the required data
-right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command 
+right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command
 line argument. Obviously, no deeper analysis via build scans is possible. The use of this configuration option requires a license
 file from Gradle Inc. to be present in the root directory of the scripts.
 
 ```bash
 ./02-validate-local-build-caching-same-location.sh -i -x
 ```
+
+## Specifying the JVM used to analyze Build Scan data
+
+The scripts use a Java-based utility to fetch and analyze Build Scan data.
+If you need to run the Java-component of the scripts with a different Java Virtual Machine than what is configured by default on your system, then you can set the `CLIENT_JAVA_HOME` environment variable when running the scripts:
+
+```bash
+CLIENT_JAVA_HOME="/opt/java/temurin-17.0.7+7" ./02-validate-local-build-caching-same-location.sh -i
+```
+
+If `CLIENT_JAVA_HOME` is not specified, then the scripts will use the JVM referenced by the `JAVA_HOME` environment variable.
+If `JAVA_HOME` is not defined, then the scripts will use the java executable found on the system path.
 
 ## Analyzing the results
 

--- a/Gradle.md
+++ b/Gradle.md
@@ -154,8 +154,13 @@ Gradle Enterprise server at ge.example.io.
 
 The scripts that run all builds locally can be configured to not publish any build scans and instead extract the required data
 right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command
-line argument. Obviously, no deeper analysis via build scans is possible. The use of this configuration option requires a license
-file from Gradle Inc. to be present in the root directory of the scripts.
+line argument. Obviously, no deeper analysis via build scans is possible.
+
+The use of this option requires at least Java 17 to analyze the Build Scan data. The JVM version to analyze the Build Scan data is
+[configurable](#specifying-the-jvm-used-to-analyze-the-build-scan-data). You can still run the builds of the experiments with a JVM 
+version lower than Java 17.
+
+The use of this configuration option also requires a license file from Gradle Inc. to be present in the root directory of the scripts.
 
 ```bash
 ./02-validate-local-build-caching-same-location.sh -i -x

--- a/Gradle.md
+++ b/Gradle.md
@@ -150,13 +150,13 @@ Gradle Enterprise server at ge.example.io.
 ./02-validate-local-build-caching-same-location.sh -i -e -s https://ge.example.io
 ```
 
-## Running the experiments without publishing build scans
+## Running the experiments without publishing Build Scan data
 
-The scripts that run all builds locally can be configured to not publish any build scans and instead extract the required data
+The scripts that run all builds locally can be configured to not publish any Build Scan data and instead extract the required data
 right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command
-line argument. Obviously, no deeper analysis via build scans is possible.
+line argument.
 
-The use of this option requires at least Java 17 to analyze the Build Scan data. The JVM version to analyze the Build Scan data is
+The use of this option requires at least Java 17 to analyze the build data. The JVM version to analyze the build data is
 [configurable](#specifying-the-jvm-used-to-analyze-the-build-scan-data). You can still run the builds of the experiments with a JVM 
 version lower than Java 17.
 
@@ -166,9 +166,9 @@ The use of this configuration option also requires a license file from Gradle In
 ./02-validate-local-build-caching-same-location.sh -i -x
 ```
 
-## Specifying the JVM used to analyze the Build Scan data
+## Specifying the JVM used to analyze the build data
 
-The scripts use a Java-based utility to fetch and analyze the captured Build Scan data.
+The scripts use a Java-based utility to fetch and analyze the captured build data.
 If you need to run the utility with a different Java Virtual Machine than what is configured by default on your system and used when running your builds,
 then you can set the `CLIENT_JAVA_HOME` environment variable when invoking the scripts:
 

--- a/Gradle.md
+++ b/Gradle.md
@@ -157,7 +157,7 @@ right during the build to surface the state of work avoidance by passing the `-x
 line argument.
 
 The use of this option requires at least Java 17 to analyze the build data. The JVM version to analyze the build data is
-[configurable](#specifying-the-jvm-used-to-analyze-the-build-scan-data). You can still run the builds of the experiments with a JVM 
+[configurable](#specifying-the-jvm-used-to-analyze-the-build-data). You can still run the builds of the experiments with a JVM 
 version lower than Java 17.
 
 The use of this configuration option also requires a license file from Gradle Inc. to be present in the root directory of the scripts.

--- a/Gradle.md
+++ b/Gradle.md
@@ -161,17 +161,18 @@ file from Gradle Inc. to be present in the root directory of the scripts.
 ./02-validate-local-build-caching-same-location.sh -i -x
 ```
 
-## Specifying the JVM used to analyze Build Scan data
+## Specifying the JVM used to analyze the Build Scan data
 
-The scripts use a Java-based utility to fetch and analyze Build Scan data.
-If you need to run the Java-component of the scripts with a different Java Virtual Machine than what is configured by default on your system, then you can set the `CLIENT_JAVA_HOME` environment variable when running the scripts:
+The scripts use a Java-based utility to fetch and analyze the captured Build Scan data.
+If you need to run the utility with a different Java Virtual Machine than what is configured by default on your system and used when running your builds,
+then you can set the `CLIENT_JAVA_HOME` environment variable when invoking the scripts:
 
 ```bash
 CLIENT_JAVA_HOME="/opt/java/temurin-17.0.7+7" ./02-validate-local-build-caching-same-location.sh -i
 ```
 
-If `CLIENT_JAVA_HOME` is not specified, then the scripts will use the JVM referenced by the `JAVA_HOME` environment variable.
-If `JAVA_HOME` is not defined, then the scripts will use the java executable found on the system path.
+If `CLIENT_JAVA_HOME` is not specified, then the utility will use the JVM referenced by the `JAVA_HOME` environment variable.
+If `JAVA_HOME` is not defined, then the utility will use the Java executable found on the system path.
 
 ## Analyzing the results
 

--- a/Maven.md
+++ b/Maven.md
@@ -155,7 +155,7 @@ right during the build to surface the state of work avoidance by passing the `-x
 line argument.
 
 The use of this option requires at least Java 17 to analyze the build data. The JVM version to analyze the build data is
-[configurable](#specifying-the-jvm-used-to-analyze-the-build-scan-data). You can still run the builds of the experiments with a JVM
+[configurable](#specifying-the-jvm-used-to-analyze-the-build-data). You can still run the builds of the experiments with a JVM
 version lower than Java 17.
 
 The use of this configuration option also requires a license file from Gradle Inc. to be present in the root directory of the scripts.

--- a/Maven.md
+++ b/Maven.md
@@ -148,13 +148,13 @@ Gradle Enterprise server at ge.example.io.
 ./01-validate-local-build-caching-same-location.sh -i -e -s https://ge.example.io
 ```
 
-## Running the experiments without publishing build scans
+## Running the experiments without publishing Build Scan data
 
-The scripts that run all builds locally can be configured to not publish any build scans and instead extract the required data
+The scripts that run all builds locally can be configured to not publish any Build Scan data and instead extract the required data
 right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command
-line argument. Obviously, no deeper analysis via build scans is possible.
+line argument.
 
-The use of this option requires at least Java 17 to analyze the Build Scan data. The JVM version to analyze the Build Scan data is
+The use of this option requires at least Java 17 to analyze the build data. The JVM version to analyze the build data is
 [configurable](#specifying-the-jvm-used-to-analyze-the-build-scan-data). You can still run the builds of the experiments with a JVM
 version lower than Java 17.
 
@@ -164,9 +164,9 @@ The use of this configuration option also requires a license file from Gradle In
 ./01-validate-local-build-caching-same-location.sh -i -x
 ```
 
-## Specifying the JVM used to analyze the Build Scan data
+## Specifying the JVM used to analyze the build data
 
-The scripts use a Java-based utility to fetch and analyze the captured Build Scan data.
+The scripts use a Java-based utility to fetch and analyze the captured build data.
 If you need to run the utility with a different Java Virtual Machine than what is configured by default on your system and used when running your builds,
 then you can set the `CLIENT_JAVA_HOME` environment variable when invoking the scripts:
 

--- a/Maven.md
+++ b/Maven.md
@@ -159,17 +159,18 @@ file from Gradle Inc. to be present in the root directory of the scripts.
 ./01-validate-local-build-caching-same-location.sh -i -x
 ```
 
-## Specifying the JVM used to analyze Build Scan data
+## Specifying the JVM used to analyze the Build Scan data
 
-The scripts use a Java-based utility to fetch and analyze Build Scan data.
-If you need to run the Java-component of the scripts with a different Java Virtual Machine than what is configured by default on your system, then you can set the `CLIENT_JAVA_HOME` environment variable when running the scripts:
+The scripts use a Java-based utility to fetch and analyze the captured Build Scan data.
+If you need to run the utility with a different Java Virtual Machine than what is configured by default on your system and used when running your builds,
+then you can set the `CLIENT_JAVA_HOME` environment variable when invoking the scripts:
 
 ```bash
 CLIENT_JAVA_HOME="/opt/java/temurin-17.0.7+7" ./01-validate-local-build-caching-same-location.sh -i
 ```
 
-If `CLIENT_JAVA_HOME` is not specified, then the scripts will use the JVM referenced by the `JAVA_HOME` environment variable.
-If `JAVA_HOME` is not defined, then the scripts will use the java executable found on the system path.
+If `CLIENT_JAVA_HOME` is not specified, then the utility will use the JVM referenced by the `JAVA_HOME` environment variable.
+If `JAVA_HOME` is not defined, then the utility will use the Java executable found on the system path.
 
 ## Analyzing the results
 

--- a/Maven.md
+++ b/Maven.md
@@ -18,7 +18,7 @@ The build validation scripts are compatible with a large range of Maven versions
 
 | Build Validation Scripts version | Compatible Maven versions | Compatible Gradle Enterprise versions |
 |----------------------------------|---------------------------| ------------------------------------- |
-| 2.0+                             | 3.3.1+                    | 2022.1+                               |  
+| 2.0+                             | 3.3.1+                    | 2022.1+                               |
 | 1.0 - 1.0.2                      | 3.3.1+                    | 2021.2+                               |
 
 ## Installation
@@ -84,7 +84,7 @@ is invoked, as shown in the example below.
 
 The scripts return with an exit code that depends on the outcome of running a given experiment.
 
-| Exit Code | Reason                                                                                                 | 
+| Exit Code | Reason                                                                                                 |
 |-----------|--------------------------------------------------------------------------------------------------------|
 | 0         | The experiment completed successfully                                                                  |
 | 1         | An invalid input was provided while attempting to run the experiment                                   |
@@ -151,13 +151,24 @@ Gradle Enterprise server at ge.example.io.
 ## Running the experiments without publishing build scans
 
 The scripts that run all builds locally can be configured to not publish any build scans and instead extract the required data
-right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command 
+right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command
 line argument. Obviously, no deeper analysis via build scans is possible. The use of this configuration option requires a license
 file from Gradle Inc. to be present in the root directory of the scripts.
 
 ```bash
 ./01-validate-local-build-caching-same-location.sh -i -x
 ```
+## Specifying the JVM used to analyze Build Scan data
+
+The scripts use a Java-based utility to fetch and analyze Build Scan data.
+If you need to run the Java-component of the scripts with a different Java Virtual Machine than what is configured by default on your system, then you can set the `CLIENT_JAVA_HOME` environment variable when running the scripts:
+
+```bash
+CLIENT_JAVA_HOME="/opt/java/temurin-17.0.7+7" ./01-validate-local-build-caching-same-location.sh -i
+```
+
+If `CLIENT_JAVA_HOME` is not specified, then the scripts will use the JVM referenced by the `JAVA_HOME` environment variable.
+If `JAVA_HOME` is not defined, then the scripts will use the java executable found on the system path.
 
 ## Analyzing the results
 

--- a/Maven.md
+++ b/Maven.md
@@ -158,6 +158,7 @@ file from Gradle Inc. to be present in the root directory of the scripts.
 ```bash
 ./01-validate-local-build-caching-same-location.sh -i -x
 ```
+
 ## Specifying the JVM used to analyze Build Scan data
 
 The scripts use a Java-based utility to fetch and analyze Build Scan data.

--- a/Maven.md
+++ b/Maven.md
@@ -152,8 +152,13 @@ Gradle Enterprise server at ge.example.io.
 
 The scripts that run all builds locally can be configured to not publish any build scans and instead extract the required data
 right during the build to surface the state of work avoidance by passing the `-x` or `--disable-build-scan-publishing` command
-line argument. Obviously, no deeper analysis via build scans is possible. The use of this configuration option requires a license
-file from Gradle Inc. to be present in the root directory of the scripts.
+line argument. Obviously, no deeper analysis via build scans is possible.
+
+The use of this option requires at least Java 17 to analyze the Build Scan data. The JVM version to analyze the Build Scan data is
+[configurable](#specifying-the-jvm-used-to-analyze-the-build-scan-data). You can still run the builds of the experiments with a JVM
+version lower than Java 17.
+
+The use of this configuration option also requires a license file from Gradle Inc. to be present in the root directory of the scripts.
 
 ```bash
 ./01-validate-local-build-caching-same-location.sh -i -x

--- a/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildScanDataCommand.java
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/java/com/gradle/enterprise/cli/FetchBuildScanDataCommand.java
@@ -56,6 +56,7 @@ public class FetchBuildScanDataCommand implements Callable<Integer> {
     public Integer call() {
         // Use System.err for logging since we're going to write out the CSV to System.out
         logger = new ConsoleLogger(System.err, colorScheme, debug);
+        logger.debug("Using JVM at " + System.getProperty("java.home"));
 
         networkSettingsFile.ifPresent(settingsFile -> NetworkSettingsConfigurator.configureNetworkSettings(settingsFile, logger));
 

--- a/components/scripts/lib/build-scan-offline.sh
+++ b/components/scripts/lib/build-scan-offline.sh
@@ -49,7 +49,7 @@ read_build_scan_dumps() {
   )
 
   echo "Extracting Build Scan data for all builds"
-  if ! build_scan_data="$(invoke_java "$READ_BUILD_SCAN_DATA_JAR" "${args[@]}")"; then
+  if ! build_scan_data="$(JAVA_HOME="${CLIENT_JAVA_HOME}" invoke_java "$READ_BUILD_SCAN_DATA_JAR" "${args[@]}")"; then
     exit "$UNEXPECTED_ERROR"
   fi
   echo "Finished extracting Build Scan data for all builds"

--- a/components/scripts/lib/build-scan-offline.sh
+++ b/components/scripts/lib/build-scan-offline.sh
@@ -49,7 +49,7 @@ read_build_scan_dumps() {
   )
 
   echo "Extracting Build Scan data for all builds"
-  if ! build_scan_data="$(JAVA_HOME="${CLIENT_JAVA_HOME}" invoke_java "$READ_BUILD_SCAN_DATA_JAR" "${args[@]}")"; then
+  if ! build_scan_data="$(JAVA_HOME="${CLIENT_JAVA_HOME:-$JAVA_HOME}" invoke_java "$READ_BUILD_SCAN_DATA_JAR" "${args[@]}")"; then
     exit "$UNEXPECTED_ERROR"
   fi
   echo "Finished extracting Build Scan data for all builds"

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -101,5 +101,5 @@ fetch_build_scan_data() {
     args+=( "${run_num},${build_scan_urls[run_num]}" )
   done
 
-  invoke_java "${FETCH_BUILD_SCAN_DATA_JAR}" "${args[@]}"
+  JAVA_HOME="${CLIENT_JAVA_HOME}" invoke_java "${FETCH_BUILD_SCAN_DATA_JAR}" "${args[@]}"
 }

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -101,5 +101,5 @@ fetch_build_scan_data() {
     args+=( "${run_num},${build_scan_urls[run_num]}" )
   done
 
-  JAVA_HOME="${CLIENT_JAVA_HOME}" invoke_java "${FETCH_BUILD_SCAN_DATA_JAR}" "${args[@]}"
+  JAVA_HOME="${CLIENT_JAVA_HOME:-$JAVA_HOME}" invoke_java "${FETCH_BUILD_SCAN_DATA_JAR}" "${args[@]}"
 }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,4 +1,4 @@
-- [NEW] Use `CLIENT_JAVA_HOME`	 environment variable to control the JVM used to run the Build Scan clients
+- [NEW] Use `CLIENT_JAVA_HOME` environment variable to control the JVM used to run the Build Scan clients
 - [NEW] Drops support for Gradle Enterprise versions older than 2023.1 when using `-e` command line option
 - [FIX] Informs the Gradle Enterprise Gradle plugin that it is being applied externally when using `-e` command line option
 - [FIX] API requests do not allow time for build scans to become available

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,4 +1,4 @@
-- [NEW] Use `CLIENT_JAVA_HOME	 environment variable to control the JVM used to run the Build Scan clients
+- [NEW] Use `CLIENT_JAVA_HOME`	 environment variable to control the JVM used to run the Build Scan clients
 - [NEW] Drops support for Gradle Enterprise versions older than 2023.1 when using `-e` command line option
 - [FIX] Informs the Gradle Enterprise Gradle plugin that it is being applied externally when using `-e` command line option
 - [FIX] API requests do not allow time for build scans to become available

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,3 +1,4 @@
+- [NEW] Use `CLIENT_JAVA_HOME	 environment variable to control the JVM used to run the Build Scan clients
 - [NEW] Drops support for Gradle Enterprise versions older than 2023.1 when using `-e` command line option
 - [FIX] Informs the Gradle Enterprise Gradle plugin that it is being applied externally when using `-e` command line option
 - [FIX] API requests do not allow time for build scans to become available

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,5 +1,5 @@
-- [NEW] Use `CLIENT_JAVA_HOME` environment variable to control the JVM used to run the Build Scan clients
-- [NEW] Drops support for Gradle Enterprise versions older than 2023.1 when using `-e` command line option
+- [NEW] Drop support for Gradle Enterprise versions older than 2023.1 when using `-e` command line option
+- [NEW] Use `CLIENT_JAVA_HOME` environment variable to control the JVM used to analyze the Build Scan data
 - [FIX] Informs the Gradle Enterprise Gradle plugin that it is being applied externally when using `-e` command line option
 - [FIX] API requests do not allow time for build scans to become available
 - [FIX] Build caching configuration is not applied to child builds


### PR DESCRIPTION
Users can use `CLIENT_JAVA_HOME` to override which JVM is used to execute the
Build Scan clients.  The other JVMs used (for running Gradle and for building
code) are not affected.

Fixes #428
