### PR TITLE
Latest Gradle Enterprise Gradle plugin and extension are used with `-e` command line option

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     argbash("argbash:argbash:2.10.0@zip")
     commonComponents(project(path = ":fetch-build-scan-data-cmdline-tool", configuration = "shadow"))
     mavenComponents(project(":configure-gradle-enterprise-maven-extension"))
-    mavenComponents("com.gradle:gradle-enterprise-maven-extension:1.16.6")
+    mavenComponents("com.gradle:gradle-enterprise-maven-extension:1.17.2")
     mavenComponents("com.gradle:common-custom-user-data-maven-extension:1.11.1")
 }
 

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly("org.apache.maven:maven-core:3.9.2")
     compileOnly("org.codehaus.plexus:plexus-component-annotations:2.1.1")
-    compileOnly("com.gradle:gradle-enterprise-maven-extension:1.16.6")
+    compileOnly("com.gradle:gradle-enterprise-maven-extension:1.17.2")
 }
 
 description = "Maven extension to capture the build scan URL"

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -16,7 +16,7 @@ invoke_gradle() {
 
   if [ "$enable_ge" == "on" ]; then
     args+=("-Dcom.gradle.enterprise.build-validation.gradle.plugin-repository.url=https://plugins.gradle.org/m2")
-    args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.plugin.version=3.12.6")
+    args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.plugin.version=3.13.3")
     args+=("-Dcom.gradle.enterprise.build-validation.ccud.plugin.version=1.10")
   fi
 

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
+- [NEW] Drop support for Gradle Enterprise versions older than 2023.1 when using `-e` command line option
 - [FIX] API requests do not allow time for build scans to become available


### PR DESCRIPTION
This PR bumps the versions of the Gradle Enterprise Gradle plugin and extension to the latest.

This means Gradle Enterprise 2023.1 or newer is required when using the `-e` command line option.