### PR TITLE
Revert "Bump com.gradle:gradle-enterprise-maven-extension from 1.17.4 to 1.18"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     argbash("argbash:argbash:2.10.0@zip")
     commonComponents(project(path = ":fetch-build-scan-data-cmdline-tool", configuration = "shadow"))
     mavenComponents(project(":configure-gradle-enterprise-maven-extension"))
-    mavenComponents("com.gradle:gradle-enterprise-maven-extension:1.18")
+    mavenComponents("com.gradle:gradle-enterprise-maven-extension:1.17.4")
     mavenComponents("com.gradle:common-custom-user-data-maven-extension:1.12.1")
 }
 

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly("org.apache.maven:maven-core:3.9.3")
     compileOnly("org.codehaus.plexus:plexus-component-annotations:2.1.1")
-    compileOnly("com.gradle:gradle-enterprise-maven-extension:1.18")
+    compileOnly("com.gradle:gradle-enterprise-maven-extension:1.17.4")
 }
 
 description = "Maven extension to capture the build scan URL"


### PR DESCRIPTION
Reverts gradle/gradle-enterprise-build-validation-scripts#466

We don't want to bump the Maven extension version before the release.