### PR TITLE
Build caching init scripts are applied to all builds

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
@@ -1,8 +1,3 @@
-def isTopLevelBuild = !gradle.parent
-if (!isTopLevelBuild) {
-    return
-}
-
 // the way this closure reads system properties means they are not tracked as inputs to the configuration cache model,
 // the same is the case when reading environment variables with Gradle [6.5, 7.3]
 def getInputParam = { String name ->

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -1,8 +1,3 @@
-def isTopLevelBuild = !gradle.parent
-if (!isTopLevelBuild) {
-    return
-}
-
 // the way this closure reads system properties means they are not tracked as inputs to the configuration cache model,
 // the same is the case when reading environment variables with Gradle [6.5, 7.3]
 def getInputParam = { String name ->

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,3 @@
 - [NEW] Drop support for Gradle Enterprise versions older than 2023.1 when using `-e` command line option
 - [FIX] API requests do not allow time for build scans to become available
+- [FIX] Build caching configuration is not applied to child builds


### PR DESCRIPTION
This PR removes the parent build checks at the beginning of the build caching init scripts.

These checks were preventing the caching configuration from being to child builds and resulted in a warning on the build cache performance screen ([Example](https://ge.solutions-team.gradle.com/s/s4fyn6jagmbec/performance/build-cache)). 

Here are some tests I ran to verify the changes:

| Project | Before | After |
|--------|--------|--------|
| AndroidX | [warning](https://ge.solutions-team.gradle.com/s/5e2yf3svxah3y/performance/build-cache) | [no warning](https://ge.solutions-team.gradle.com/s/kgstgs56jpaz2/performance/build-cache) |
| Caffeine | [warning](https://ge.solutions-team.gradle.com/s/5wco2hntuo7de/performance/build-cache) | [no warning](https://ge.solutions-team.gradle.com/s/zpkdhrrjkvzrg/performance/build-cache) | 
| java-ordered-properties | [no warning](https://ge.solutions-team.gradle.com/s/apeoai2bcjoqi/performance/build-cache) | [no warning](https://ge.solutions-team.gradle.com/s/ipeoz2aoxcjtg/performance/build-cache) |
| JUnit | [warning](https://ge.solutions-team.gradle.com/s/uawxfvdrm4qjy/performance/build-cache) | [no warning](https://ge.solutions-team.gradle.com/s/5bbc6cuqz2afi/performance/build-cache) |
| Spring Authorization Server | [no warning](https://ge.solutions-team.gradle.com/s/rroig357sqdno/performance/build-cache) | [no warning](https://ge.solutions-team.gradle.com/s/j7upnlnc2kbmg/performance/build-cache) |