### PR TITLE
Update only patch version of GE Maven extension

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     directory: "/"
     registries:
       - gradle-plugin-portal
+    ignore:
+      # Update only patch version of GE Maven extension
+      - dependency-name: "com.gradle:gradle-enterprise-maven-extension"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     schedule:
       interval: "daily"
       time: "02:00"


### PR DESCRIPTION
### Issue
fixes https://github.com/gradle/gradle-enterprise-build-validation-scripts/issues/472

### Fix
Use an [ignore](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore) rule to have Dependabot ignore Major and Minor updates of the GE Maven extension
