### PR TITLE
Invalid JVM version error message is handled in the scripts 

### DIFF
--- a/components/scripts/lib/build-scan-offline.sh
+++ b/components/scripts/lib/build-scan-offline.sh
@@ -2,6 +2,10 @@
 
 readonly READ_BUILD_SCAN_DATA_JAR="${LIB_DIR}/build-scan-clients/build-scan-summary-${SUMMARY_VERSION}.jar"
 
+# Build scan summary exit codes
+readonly SUCCESS=0
+readonly JVM_VERSION_NOT_SUPPORTED=3
+
 build_scan_dumps=()
 
 find_and_read_build_scan_dumps() {
@@ -28,16 +32,19 @@ find_build_scan_dump() {
 }
 
 read_build_scan_dumps() {
-  local build_scan_data args
-  args=()
+  local args build_scan_data build_scan_summary_exit_code
 
-  args+=(
-      "0,file://${build_scan_dumps[0]}"
-      "1,file://${build_scan_dumps[1]}"
+  args=(
+    "0,file://${build_scan_dumps[0]}"
+    "1,file://${build_scan_dumps[1]}"
   )
 
   echo "Extracting Build Scan data for all builds"
-  if ! build_scan_data="$(JAVA_HOME="${CLIENT_JAVA_HOME:-$JAVA_HOME}" invoke_java "$READ_BUILD_SCAN_DATA_JAR" "${args[@]}")"; then
+  build_scan_data="$(JAVA_HOME="${CLIENT_JAVA_HOME:-$JAVA_HOME}" invoke_java "$READ_BUILD_SCAN_DATA_JAR" "${args[@]}")"
+  build_scan_summary_exit_code="$?"
+  if [[ $build_scan_summary_exit_code -eq $JVM_VERSION_NOT_SUPPORTED ]]; then
+    die "ERROR: Java 17+ is required when using --disable-build-scan-publishing. Rerun the script with Java 17+ or set the environment variable CLIENT_JAVA_HOME to a Java 17+ installation." "$UNEXPECTED_ERROR"
+  elif [[ $build_scan_summary_exit_code -ne $SUCCESS ]]; then
     exit "$UNEXPECTED_ERROR"
   fi
   echo "Finished extracting Build Scan data for all builds"

--- a/components/scripts/lib/build-scan-offline.sh
+++ b/components/scripts/lib/build-scan-offline.sh
@@ -43,7 +43,7 @@ read_build_scan_dumps() {
   build_scan_data="$(JAVA_HOME="${CLIENT_JAVA_HOME:-$JAVA_HOME}" invoke_java "$READ_BUILD_SCAN_DATA_JAR" "${args[@]}")"
   build_scan_summary_exit_code="$?"
   if [[ $build_scan_summary_exit_code -eq $JVM_VERSION_NOT_SUPPORTED ]]; then
-    die "ERROR: Java 17+ is required when using --disable-build-scan-publishing. Rerun the script with Java 17+ or set the environment variable CLIENT_JAVA_HOME to a Java 17+ installation." "$UNEXPECTED_ERROR"
+    die "ERROR: Java 17+ is required when using --disable-build-scan-publishing. Rerun the script with Java 17+ or set the CLIENT_JAVA_HOME environment variable to a Java 17+ installation." "$UNEXPECTED_ERROR"
   elif [[ $build_scan_summary_exit_code -ne $SUCCESS ]]; then
     exit "$UNEXPECTED_ERROR"
   fi


### PR DESCRIPTION
Adds specific error handling for an invalid JVM version. Other non-zero exit codes are treated as an unexpected error.

# Testing

Below are all of the test cases I ran to verify these changes.

## Running with `-x` and Java 8

```shell
$ java -version            
openjdk version "1.8.0_362"
$ ./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/8.x/ge -t 'build' -x
```

This results in the following:

<img width="1108" alt="image" src="https://github.com/gradle/gradle-enterprise-build-validation-scripts/assets/5797900/03260844-003c-4c01-848e-0b49d0606ed5">

## Running with `-x`, Java 8, and setting CLIENT_JAVA_HOME

```shell
$ java -version            
openjdk version "1.8.0_362"
$ CLIENT_JAVA_HOME="$JDK17" ./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/8.x/ge -t 'build' -x
```

This results in the following:

<img width="1116" alt="image" src="https://github.com/gradle/gradle-enterprise-build-validation-scripts/assets/5797900/21544a20-b380-4ea3-b48a-f42906d65b89">

## Running with `-x` and Java 17

```shell
$ java -version
openjdk version "17.0.6" 2023-01-17
$ ./03-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/ge-solutions.git -p sample-projects/gradle/8.x/ge -t 'build' -x                                 
```

This results in the following:

<img width="1105" alt="image" src="https://github.com/gradle/gradle-enterprise-build-validation-scripts/assets/5797900/f2ed8a6c-9552-4608-ba31-3550ff8f2521">