### PR TITLE
Bump WSL distribution from Ubuntu-20.04 to Ubuntu-22.04

### DIFF
--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: Vampire/setup-wsl@v2
         with:
-          distribution: Ubuntu-20.04
+          distribution: Ubuntu-22.04
           additional-packages: curl unzip wget apt-transport-https gnupg
       - name: Set up JDK ${{ matrix.java-version }} on WSL
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: Vampire/setup-wsl@v2
         with:
-          distribution: Ubuntu-20.04
+          distribution: Ubuntu-22.04
           additional-packages: curl unzip wget apt-transport-https gnupg
       - name: Set up JDK ${{ matrix.java-version }} on WSL
         if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
This PR updates the version of Ubuntu from 20.04 to 22.04 to resolve issues with the certificate verification seen here: https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/6435049099/job/17475524181