### PR TITLE
Support Develocity API 2023.3.2+ for building experiment summary

### DIFF
--- a/components/fetch-build-scan-data-cmdline-tool/src/main/openapi/openapi.yaml
+++ b/components/fetch-build-scan-data-cmdline-tool/src/main/openapi/openapi.yaml
@@ -1487,7 +1487,6 @@ components:
       description: Information about the local build cache used in the build.
       required:
         - isEnabled
-        - isDisabledDueToError
       properties:
         isEnabled:
           type: boolean
@@ -1503,6 +1502,7 @@ components:
           description: >-
             Whether the local cache was disabled due to an error occuring in
             loading or storing local build cache entries.
+          x-nullable: true
         directory:
           type: string
           description: >-
@@ -1515,7 +1515,6 @@ components:
       description: Information about the remote build cache used in the build.
       required:
         - isEnabled
-        - isDisabledDueToError
       properties:
         isEnabled:
           type: boolean
@@ -1531,6 +1530,7 @@ components:
           description: >-
             Wether the remote build cache was disabled during the build due to
             an error occuring in loading or storing remote build cache entries.
+          x-nullable: true
         url:
           type: string
           description: >-
@@ -1797,7 +1797,6 @@ components:
       x-nullable: true
       required:
         - isEnabled
-        - isDisabledDueToError
       properties:
         isEnabled:
           type: boolean
@@ -1813,6 +1812,7 @@ components:
           description: >-
             Whether the local cache was disabled due to an error occuring in
             loading or storing local build cache entries.
+          x-nullable: true
         directory:
           type: string
           description: >-
@@ -1829,7 +1829,6 @@ components:
       x-nullable: true
       required:
         - isEnabled
-        - isDisabledDueToError
       properties:
         isEnabled:
           type: boolean
@@ -1845,6 +1844,7 @@ components:
           description: >-
             Whether the remote build cache was disabled during the build due to
             an error occuring in loading or storing remote build cache entries.
+          x-nullable: true
         url:
           type: string
           description: >-


### PR DESCRIPTION
This PR adds support for Develocity instances running 2023.3.2 and greater when creating the experiment summary. 

This resolves the `ERROR: The required field 'isDisabledDueToError' is not found in the JSON string: {"isEnabled":false}` that is seen when running the scripts with a Develocity instance running 2023.3.2.

Before: https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/6543580559/job/17768404455#step:7:84
After: https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/6566328643/job/17837095215#step:8:84