### PR TITLE
Bump injected Common Custom User Data Gradle plugin version from 1.12.2 to 1.13

### DIFF
--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -17,7 +17,7 @@ invoke_gradle() {
   if [ "$enable_ge" == "on" ]; then
     args+=("-Dcom.gradle.enterprise.build-validation.gradle.plugin-repository.url=https://plugins.gradle.org/m2")
     args+=("-Dcom.gradle.enterprise.build-validation.gradle-enterprise.plugin.version=3.14.1")
-    args+=("-Dcom.gradle.enterprise.build-validation.ccud.plugin.version=1.12.2")
+    args+=("-Dcom.gradle.enterprise.build-validation.ccud.plugin.version=1.13")
   fi
 
   if [ -n "${ge_server}" ]; then


### PR DESCRIPTION
This PR bumps the injected Common Custom User Data Gradle plugin version from 1.12.3 to 1.13.