### PR TITLE
Configure both GE and Develocity extensions available in the evaluated project

### DIFF
--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -143,9 +143,13 @@ execute_build() {
   #shellcheck disable=SC2086  # we actually want ${tasks} to expand because it may have more than one maven goal
   invoke_maven "${run_num}" \
      -Dgradle.cache.local.enabled=true \
+     -Ddevelocity.cache.local.enabled=true \
      -Dgradle.cache.local.storeEnabled=true \
+     -Ddevelocity.cache.local.storeEnabled=true \
      -Dgradle.cache.remote.enabled=false \
+     -Ddevelocity.cache.remote.enabled=false \
      -Dgradle.cache.local.directory="${BUILD_CACHE_DIR}" \
+     -Ddevelocity.cache.local.directory="${BUILD_CACHE_DIR}" \
      clean ${tasks}
 }
 

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -147,9 +147,13 @@ execute_build() {
   # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
   invoke_maven "${run_num}" \
      -Dgradle.cache.local.enabled=true \
+     -Ddevelocity.cache.local.enabled=true \
      -Dgradle.cache.local.storeEnabled=true \
+     -Ddevelocity.cache.local.storeEnabled=true \
      -Dgradle.cache.remote.enabled=false \
+     -Ddevelocity.cache.remote.enabled=false \
      -Dgradle.cache.local.directory="${BUILD_CACHE_DIR}" \
+     -Ddevelocity.cache.local.directory="${BUILD_CACHE_DIR}" \
      clean ${tasks}
 }
 

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -192,9 +192,9 @@ validate_build_config() {
 
 execute_build() {
   local args
-  args=(-Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=true)
+  args=(-Dgradle.cache.local.enabled=false -Ddevelocity.cache.local.enabled=false -Dgradle.cache.remote.enabled=true -Ddevelocity.cache.remote.enabled=true)
   if [ -n "${remote_build_cache_url}" ]; then
-    args+=("-Dgradle.cache.remote.url=${remote_build_cache_url}")
+    args+=("-Dgradle.cache.remote.url=${remote_build_cache_url} -Ddevelocity.cache.remote.url=${remote_build_cache_url}")
   fi
 
   # shellcheck disable=SC2206  # we want tasks to expand with word splitting in this case


### PR DESCRIPTION
## Summary
Maven validation scripts interact with the extension using system properties (primarily for cache configuration). In this PR, we now set properties both for the GE and Develocity extension, making it forwards compatible with extension versions available under the Develocity name.