### PR TITLE
Fix running argbash on MacOS

### DIFF
--- a/buildSrc/src/main/kotlin/ApplyArgbash.kt
+++ b/buildSrc/src/main/kotlin/ApplyArgbash.kt
@@ -50,7 +50,7 @@ abstract class ApplyArgbash @Inject constructor(
 
                 logger.info("Applying argbash to $file")
                 execOperations.exec {
-                    commandLine(argbash, file, "-o", outputFile)
+                    commandLine("/usr/bin/env", "bash", argbash, file, "-o", outputFile)
                 }
             }
         }


### PR DESCRIPTION
argbash uses `#!/bin/bash`. On MacOS, this means the MacOS version of bash will
be used. This wasn't a problem in the past, but it appears to be an issue now
(maybe because of a change to one of the recent Gradle versions, or maybe
because of a recent MacOS update). When MacOS bash was used, argbash would fail
with a syntax error. This is because it uses bash features that are not
available in the MacOS version of bash.

The solution is to use /usr/bin/env bash to invoke argbash, which then uses
whatever version of bash is first on the system path. For MacOS developers,
this will be a more recent GNU version of bash.
