### PR TITLE
Enable debug logging for the validation scripts when GitHub Actions debug logging is enabled

### DIFF
--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -29,6 +29,9 @@ inputs:
   enableGradleEnterprise:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
+  debug:
+    description: "Enable debug logging for this experiment of the build validation scripts"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -80,6 +83,10 @@ runs:
         if [ "${{ inputs.enableGradleEnterprise }}" == "true" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
+        ARG_DEBUG=""
+        if [ "${{ inputs.debug }}" == "true" ]; then
+          ARG_DEBUG="${{ inputs.debug }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -94,7 +101,8 @@ runs:
           ${ARG_TASKS:+"-t" "$ARG_TASKS"} \
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
-          ${ARG_GE_ENABLE:+"-e"}
+          ${ARG_GE_ENABLE:+"-e"} \
+          ${ARG_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/01-validate-incremental-building/latest/exp1-*.receipt"

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -29,9 +29,6 @@ inputs:
   enableGradleEnterprise:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
-  debug:
-    description: "Enable debug logging for this experiment of the build validation scripts"
-    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -83,10 +80,6 @@ runs:
         if [ "${{ inputs.enableGradleEnterprise }}" == "true" ]; then
           ARG_GE_ENABLE="${{ inputs.enableGradleEnterprise }}"
         fi
-        ARG_DEBUG=""
-        if [ "${{ inputs.debug }}" == "true" ]; then
-          ARG_DEBUG="${{ inputs.debug }}"
-        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -102,7 +95,7 @@ runs:
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
-          ${ARG_DEBUG:+"--debug"}
+          ${RUNNER_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/01-validate-incremental-building/latest/exp1-*.receipt"

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -32,6 +32,9 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
+  debug:
+    description: "Enable debug logging for this experiment of the build validation scripts"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -87,6 +90,10 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
+        ARG_DEBUG=""
+        if [ "${{ inputs.debug }}" == "true" ]; then
+          ARG_DEBUG="${{ inputs.debug }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -102,7 +109,8 @@ runs:
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
-          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
+          ${ARG_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -32,9 +32,6 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
-  debug:
-    description: "Enable debug logging for this experiment of the build validation scripts"
-    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -90,10 +87,6 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
-        ARG_DEBUG=""
-        if [ "${{ inputs.debug }}" == "true" ]; then
-          ARG_DEBUG="${{ inputs.debug }}"
-        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -110,7 +103,7 @@ runs:
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
-          ${ARG_DEBUG:+"--debug"}
+          ${RUNNER_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -32,6 +32,9 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
+  debug:
+    description: "Enable debug logging for this experiment of the build validation scripts"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -87,6 +90,10 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
+        ARG_DEBUG=""
+        if [ "${{ inputs.debug }}" == "true" ]; then
+          ARG_DEBUG="${{ inputs.debug }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -102,7 +109,8 @@ runs:
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
-          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
+          ${ARG_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -32,9 +32,6 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
-  debug:
-    description: "Enable debug logging for this experiment of the build validation scripts"
-    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -90,10 +87,6 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
-        ARG_DEBUG=""
-        if [ "${{ inputs.debug }}" == "true" ]; then
-          ARG_DEBUG="${{ inputs.debug }}"
-        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-gradle-build-validation
@@ -110,7 +103,7 @@ runs:
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
-          ${ARG_DEBUG:+"--debug"}
+          ${RUNNER_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -32,9 +32,6 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
-  debug:
-    description: "Enable debug logging for this experiment of the build validation scripts"
-    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -90,10 +87,6 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
-        ARG_DEBUG=""
-        if [ "${{ inputs.debug }}" == "true" ]; then
-          ARG_DEBUG="${{ inputs.debug }}"
-        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-maven-build-validation
@@ -110,7 +103,7 @@ runs:
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
-          ${ARG_DEBUG:+"--debug"}
+          ${RUNNER_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -32,6 +32,9 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
+  debug:
+    description: "Enable debug logging for this experiment of the build validation scripts"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -87,6 +90,10 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
+        ARG_DEBUG=""
+        if [ "${{ inputs.debug }}" == "true" ]; then
+          ARG_DEBUG="${{ inputs.debug }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-maven-build-validation
@@ -102,7 +109,8 @@ runs:
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
-          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
+          ${ARG_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -32,6 +32,9 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
+  debug:
+    description: "Enable debug logging for this experiment of the build validation scripts"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -87,6 +90,10 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
+        ARG_DEBUG=""
+        if [ "${{ inputs.debug }}" == "true" ]; then
+          ARG_DEBUG="${{ inputs.debug }}"
+        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-maven-build-validation
@@ -102,7 +109,8 @@ runs:
           ${ARG_ARGS:+"-a" "$ARG_ARGS"} \
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
-          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"}
+          ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
+          ${ARG_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -32,9 +32,6 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
-  debug:
-    description: "Enable debug logging for this experiment of the build validation scripts"
-    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -90,10 +87,6 @@ runs:
         if [ "${{ inputs.failIfNotFullyCacheable }}" == "true" ]; then
           ARG_FAIL_IF_NOT_FULLY_CACHEABLE="${{ inputs.failIfNotFullyCacheable }}"
         fi
-        ARG_DEBUG=""
-        if [ "${{ inputs.debug }}" == "true" ]; then
-          ARG_DEBUG="${{ inputs.debug }}"
-        fi
 
         # Navigate into the folder containing the validation scripts
         cd gradle-enterprise-maven-build-validation
@@ -110,7 +103,7 @@ runs:
           ${ARG_GE_URL:+"-s" "$ARG_GE_URL"} \
           ${ARG_GE_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
-          ${ARG_DEBUG:+"--debug"}
+          ${RUNNER_DEBUG:+"--debug"}
 
         # Set the Build Scan urls as outputs
         RECEIPT_FILE=".data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"


### PR DESCRIPTION
Currently the GitHub actions for executing the experiments does not include a way to enable debug logging for the validation scripts. This is problematic if there is an issue that only reproduces in CI. This PR updates the experiment actions to read the default environment variable `RUNNER_DEBUG` to toggle debug logging for the validation scripts. If jobs are re-run with the "Enable debug logging" box checked, the `RUNNER_DEBUG` environment variable is set, and debug logging will be enabled for the validation scripts.