### PR TITLE
Upgrade Shellcheck to v0.10.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 
 shellcheck {
     additionalArguments = "-a -x"
-    shellcheckVersion = "v0.8.0"
+    shellcheckVersion = "v0.10.0"
 }
 
 val unpackArgbash by tasks.registering(Copy::class) {

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -28,10 +28,10 @@ read_build_scan_metadata() {
 
     # shellcheck disable=SC2034
     while IFS=, read -r run_num project_name base_url build_scan_url build_scan_id; do
-       project_names[$run_num]="${project_name}"
-       base_urls[$run_num]="${base_url}"
-       build_scan_urls[$run_num]="${build_scan_url}"
-       build_scan_ids[$run_num]="${build_scan_id}"
+       project_names[run_num]="${project_name}"
+       base_urls[run_num]="${base_url}"
+       build_scan_urls[run_num]="${build_scan_url}"
+       build_scan_ids[run_num]="${build_scan_id}"
     done <<< "${build_scan_metadata}"
   fi
 }


### PR DESCRIPTION
Dependabot does not upgrade Shellcheck because it isn't declared like a normal dependency.

Also addresses [SC2004](https://www.shellcheck.net/wiki/SC2004), which was detected by the new version of shellcheck.

