### PR TITLE
Add support for the renamed Develocity Maven Extension

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       # Update only patch version of GE Maven extension
       - dependency-name: "com.gradle:gradle-enterprise-maven-extension"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # intentionally compiling against an older version to preserve compatibility with older versions of Maven
+      - dependency-name: "org.apache.maven:maven-core"
     schedule:
       interval: "daily"
       time: "02:00"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ val isDevelopmentRelease = !hasProperty("finalRelease")
 val releaseVersion = releaseVersion()
 val releaseNotes = releaseNotes()
 val distributionVersion = distributionVersion()
+extra["develocityMavenExtensionAdaptersVersion"] = "1.0"
 
 allprojects {
     version = releaseVersion.get()
@@ -96,6 +97,8 @@ val copyGradleScripts by tasks.registering(Copy::class) {
     // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:not_yet_implemented:accessing_top_level_at_execution
     val releaseVersion = releaseVersion
     inputs.property("project.version", releaseVersion)
+    val mavenExtensionAdaptersVersion = rootProject.extra["develocityMavenExtensionAdaptersVersion"].toString()
+    inputs.property("develocityMavenExtensionAdaptersVersion", mavenExtensionAdaptersVersion)
 
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
@@ -116,6 +119,7 @@ val copyGradleScripts by tasks.registering(Copy::class) {
         include("lib/**")
         exclude("lib/cli-parsers")
         filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
+        filter { line: String -> line.replace("<EXTENSION_ADAPTERS_VERSION>", mavenExtensionAdaptersVersion) }
     }
     from(generateBashCliParsers.map { it.outputDir.file("lib/cli-parsers/gradle") }) {
         into("lib/")
@@ -134,6 +138,8 @@ val copyMavenScripts by tasks.registering(Copy::class) {
     // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:not_yet_implemented:accessing_top_level_at_execution
     val releaseVersion = releaseVersion
     inputs.property("project.version", releaseVersion)
+    val mavenExtensionAdaptersVersion = rootProject.extra["develocityMavenExtensionAdaptersVersion"].toString()
+    inputs.property("develocityMavenExtensionAdaptersVersion", mavenExtensionAdaptersVersion)
 
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
@@ -149,6 +155,7 @@ val copyMavenScripts by tasks.registering(Copy::class) {
         include("lib/**")
         exclude("lib/cli-parsers")
         filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
+        filter { line: String -> line.replace("<EXTENSION_ADAPTERS_VERSION>", mavenExtensionAdaptersVersion) }
     }
     from(generateBashCliParsers.map { it.outputDir.file("lib/cli-parsers/maven") }) {
         into("lib/")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ val isDevelopmentRelease = !hasProperty("finalRelease")
 val releaseVersion = releaseVersion()
 val releaseNotes = releaseNotes()
 val distributionVersion = distributionVersion()
-extra["develocityMavenExtensionAdaptersVersion"] = "1.0"
 
 allprojects {
     version = releaseVersion.get()
@@ -49,7 +48,7 @@ val mavenComponents by configurations.creating
 dependencies {
     argbash("argbash:argbash:2.10.0@zip")
     commonComponents(project(path = ":fetch-build-scan-data-cmdline-tool", configuration = "shadow"))
-    mavenComponents(project(":configure-gradle-enterprise-maven-extension"))
+    mavenComponents(project(path = ":configure-gradle-enterprise-maven-extension", configuration = "shadow"))
     mavenComponents("com.gradle:gradle-enterprise-maven-extension:1.18.4")
     mavenComponents("com.gradle:common-custom-user-data-maven-extension:1.13")
 }
@@ -97,8 +96,6 @@ val copyGradleScripts by tasks.registering(Copy::class) {
     // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:not_yet_implemented:accessing_top_level_at_execution
     val releaseVersion = releaseVersion
     inputs.property("project.version", releaseVersion)
-    val mavenExtensionAdaptersVersion = rootProject.extra["develocityMavenExtensionAdaptersVersion"].toString()
-    inputs.property("develocityMavenExtensionAdaptersVersion", mavenExtensionAdaptersVersion)
 
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
@@ -119,7 +116,6 @@ val copyGradleScripts by tasks.registering(Copy::class) {
         include("lib/**")
         exclude("lib/cli-parsers")
         filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
-        filter { line: String -> line.replace("<EXTENSION_ADAPTERS_VERSION>", mavenExtensionAdaptersVersion) }
     }
     from(generateBashCliParsers.map { it.outputDir.file("lib/cli-parsers/gradle") }) {
         into("lib/")
@@ -138,8 +134,6 @@ val copyMavenScripts by tasks.registering(Copy::class) {
     // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:not_yet_implemented:accessing_top_level_at_execution
     val releaseVersion = releaseVersion
     inputs.property("project.version", releaseVersion)
-    val mavenExtensionAdaptersVersion = rootProject.extra["develocityMavenExtensionAdaptersVersion"].toString()
-    inputs.property("develocityMavenExtensionAdaptersVersion", mavenExtensionAdaptersVersion)
 
     from(layout.projectDirectory.file("LICENSE"))
     from(layout.projectDirectory.dir("release").file("version.txt"))
@@ -155,7 +149,6 @@ val copyMavenScripts by tasks.registering(Copy::class) {
         include("lib/**")
         exclude("lib/cli-parsers")
         filter { line: String -> line.replace("<HEAD>", releaseVersion.get()) }
-        filter { line: String -> line.replace("<EXTENSION_ADAPTERS_VERSION>", mavenExtensionAdaptersVersion) }
     }
     from(generateBashCliParsers.map { it.outputDir.file("lib/cli-parsers/maven") }) {
         into("lib/")

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java")
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 repositories {
@@ -10,7 +11,7 @@ dependencies {
     compileOnly("org.apache.maven:maven-core:3.9.6")
     compileOnly("org.codehaus.plexus:plexus-component-annotations:2.2.0")
     compileOnly("com.gradle:develocity-maven-extension:1.21.3")
-    implementation("com.gradle:develocity-maven-extension-adapters:${rootProject.extra["develocityMavenExtensionAdaptersVersion"]}")
+    implementation("com.gradle:develocity-maven-extension-adapters:1.0")
 }
 
 description = "Maven extension to capture the build scan URL"

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -25,4 +25,5 @@ java {
 
 tasks.withType(JavaCompile::class).configureEach {
     options.encoding = "UTF-8"
+    options.compilerArgs.add("-Xlint:deprecation")
 }

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -9,7 +9,8 @@ repositories {
 dependencies {
     compileOnly("org.apache.maven:maven-core:3.9.6")
     compileOnly("org.codehaus.plexus:plexus-component-annotations:2.2.0")
-    compileOnly("com.gradle:gradle-enterprise-maven-extension:1.18.4")
+    compileOnly("com.gradle:develocity-maven-extension:1.21.3")
+    implementation("com.gradle:develocity-maven-extension-adapters:${rootProject.extra["develocityMavenExtensionAdaptersVersion"]}")
 }
 
 description = "Maven extension to capture the build scan URL"

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     compileOnly("org.apache.maven:maven-core:3.6.3")  // intentionally compiling against an older version to preserve compatibility with older versions of Maven
     compileOnly("org.codehaus.plexus:plexus-component-annotations:2.2.0")
-    compileOnly("com.gradle:develocity-maven-extension:1.21.3")
+    compileOnly("com.gradle:develocity-maven-extension:1.21.4")
     implementation("com.gradle:develocity-maven-extension-adapters:1.0")
 }
 

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -25,5 +25,4 @@ java {
 
 tasks.withType(JavaCompile::class).configureEach {
     options.encoding = "UTF-8"
-    options.compilerArgs.add("-Xlint:deprecation")
 }

--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.apache.maven:maven-core:3.9.6")
+    compileOnly("org.apache.maven:maven-core:3.6.3")  // intentionally compiling against an older version to preserve compatibility with older versions of Maven
     compileOnly("org.codehaus.plexus:plexus-component-annotations:2.2.0")
     compileOnly("com.gradle:develocity-maven-extension:1.21.3")
     implementation("com.gradle:develocity-maven-extension-adapters:1.0")

--- a/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocity.java
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocity.java
@@ -1,0 +1,27 @@
+package com.gradle;
+
+import com.gradle.develocity.agent.maven.adapters.develocity.DevelocityApiAdapter;
+import com.gradle.develocity.agent.maven.api.DevelocityApi;
+import com.gradle.develocity.agent.maven.api.DevelocityListener;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.logging.Logger;
+
+import javax.inject.Inject;
+
+@SuppressWarnings("unused")
+public class ConfigureDevelocity implements DevelocityListener {
+
+    private static final String EXPERIMENT_DIR = System.getProperty("com.gradle.enterprise.build-validation.expDir");
+
+    private final ConfigureDevelocityAdaptor configureDevelocityAdaptor;
+
+    @Inject
+    public ConfigureDevelocity(ConfigureDevelocityAdaptor configureDevelocityAdaptor, RootProjectExtractor rootProjectExtractor, Logger logger) {
+        this.configureDevelocityAdaptor = configureDevelocityAdaptor;
+    }
+
+    @Override
+    public void configure(DevelocityApi api, MavenSession session) {
+        configureDevelocityAdaptor.configure(new DevelocityApiAdapter(api), session);
+    }
+}

--- a/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocity.java
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocity.java
@@ -4,19 +4,15 @@ import com.gradle.develocity.agent.maven.adapters.develocity.DevelocityApiAdapte
 import com.gradle.develocity.agent.maven.api.DevelocityApi;
 import com.gradle.develocity.agent.maven.api.DevelocityListener;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.logging.Logger;
 
 import javax.inject.Inject;
 
-@SuppressWarnings("unused")
 public class ConfigureDevelocity implements DevelocityListener {
-
-    private static final String EXPERIMENT_DIR = System.getProperty("com.gradle.enterprise.build-validation.expDir");
 
     private final ConfigureDevelocityAdaptor configureDevelocityAdaptor;
 
     @Inject
-    public ConfigureDevelocity(ConfigureDevelocityAdaptor configureDevelocityAdaptor, RootProjectExtractor rootProjectExtractor, Logger logger) {
+    public ConfigureDevelocity(ConfigureDevelocityAdaptor configureDevelocityAdaptor, RootProjectExtractor rootProjectExtractor) {
         this.configureDevelocityAdaptor = configureDevelocityAdaptor;
     }
 

--- a/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocityAdaptor.java
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocityAdaptor.java
@@ -1,0 +1,125 @@
+package com.gradle;
+
+import com.gradle.develocity.agent.maven.adapters.BuildScanApiAdapter;
+import com.gradle.develocity.agent.maven.adapters.DevelocityAdapter;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.logging.Logger;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.nio.file.StandardOpenOption.*;
+
+public class ConfigureDevelocityAdaptor {
+
+    private static final String EXPERIMENT_DIR = System.getProperty("com.gradle.enterprise.build-validation.expDir");
+
+    private final RootProjectExtractor rootProjectExtractor;
+    private final Logger logger;
+
+    @Inject
+    public ConfigureDevelocityAdaptor(RootProjectExtractor rootProjectExtractor, Logger logger) {
+        this.rootProjectExtractor = rootProjectExtractor;
+        this.logger = logger;
+    }
+
+    public void configure(DevelocityAdapter api, MavenSession session) {
+        logger.debug("Configuring build scan published event...");
+
+        BuildScanApiAdapter buildScan = api.getBuildScan();
+
+        String geUrl = System.getProperty("gradle.enterprise.url");
+        String geAllowUntrustedServer = System.getProperty("gradle.enterprise.allowUntrustedServer");
+
+        if (geUrl != null && !geUrl.isEmpty()) {
+            buildScan.setServer(geUrl);
+        }
+        if (geAllowUntrustedServer != null && !geAllowUntrustedServer.isEmpty()) {
+            buildScan.setAllowUntrustedServer(Boolean.parseBoolean(geAllowUntrustedServer));
+        }
+
+        String rootProjectName = rootProjectExtractor.extractRootProject(session).getName();
+
+        registerBuildScanActions(buildScan, rootProjectName);
+        configureBuildScanPublishing(buildScan);
+    }
+
+    private static void registerBuildScanActions(BuildScanApiAdapter buildScan, String rootProjectName) {
+        buildScan.buildFinished(buildResult -> {
+            // communicate via error file that no GE server is set
+            boolean omitServerUrlValidation = parseBoolean(System.getProperty("com.gradle.enterprise.build-validation.omitServerUrlValidation"));
+            if (buildScan.getServer() == null && !omitServerUrlValidation) {
+                buildScan.publishAlwaysIf(false); // disable publishing, otherwise scans.gradle.com will be used
+                File errorFile = new File(EXPERIMENT_DIR, "errors.txt");
+                append(errorFile, "The Gradle Enterprise server URL has not been configured in the project or on the command line.");
+            }
+        });
+
+        buildScan.buildFinished(buildResult -> {
+            String expId = System.getProperty("com.gradle.enterprise.build-validation.expId");
+            addCustomValueAndSearchLink(buildScan, "Experiment id", expId);
+            buildScan.tag(expId);
+
+            String runId = System.getProperty("com.gradle.enterprise.build-validation.runId");
+            addCustomValueAndSearchLink(buildScan, "Experiment run id", runId);
+
+            String scriptsVersion = System.getProperty("com.gradle.enterprise.build-validation.scriptsVersion");
+            buildScan.value("Build validation scripts", scriptsVersion);
+        });
+
+        buildScan.buildScanPublished(scan -> {
+            String runNum = System.getProperty("com.gradle.enterprise.build-validation.runNum");
+            URI buildScanUri = scan.getBuildScanUri();
+            String buildScanId = scan.getBuildScanId();
+            String port = buildScanUri.getPort() != -1 ? ":" + buildScanUri.getPort() : "";
+            String baseUrl = String.format("%s://%s%s", buildScanUri.getScheme(), buildScanUri.getHost(), port);
+
+            File scanFile = new File(EXPERIMENT_DIR, "build-scans.csv");
+            append(scanFile, String.format("%s,%s,%s,%s,%s\n", runNum, rootProjectName, baseUrl, buildScanUri, buildScanId));
+        });
+    }
+
+    private static void configureBuildScanPublishing(BuildScanApiAdapter buildScan) {
+        buildScan.publishAlways();
+        buildScan.capture(t -> t.setGoalInputFiles(true)); // also set via sys prop
+        buildScan.setUploadInBackground(false);
+    }
+
+    private static void addCustomValueAndSearchLink(BuildScanApiAdapter buildScan, String label, String value) {
+        buildScan.value(label, value);
+        if (buildScan.getServer() != null) {
+            String server = buildScan.getServer();
+            String searchParams = "search.names=" + urlEncode(label) + "&search.values=" + urlEncode(value);
+            String url = appendIfMissing(server, "/") + "scans?" + searchParams + "#selection.buildScanB=" + urlEncode("{SCAN_ID}");
+            buildScan.link(label + " build scans", url);
+        }
+    }
+
+    private static String appendIfMissing(String str, String suffix) {
+        return str.endsWith(suffix) ? str : str + suffix;
+    }
+
+    private static String urlEncode(String str) {
+        try {
+            return URLEncoder.encode(str, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void append(File file, String text) {
+        try {
+            Files.write(file.toPath(), text.getBytes(), CREATE, WRITE, APPEND);
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Unable to write to file %s: %s", file.getName(), e.getMessage()), e);
+        }
+    }
+
+}

--- a/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureGradleEnterprise.java
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureGradleEnterprise.java
@@ -1,128 +1,25 @@
 package com.gradle;
 
+import com.gradle.develocity.agent.maven.adapters.enterprise.GradleEnterpriseApiAdapter;
 import com.gradle.maven.extension.api.GradleEnterpriseApi;
 import com.gradle.maven.extension.api.GradleEnterpriseListener;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.logging.Logger;
 
 import javax.inject.Inject;
-import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
-import static java.lang.Boolean.parseBoolean;
-import static java.nio.file.StandardOpenOption.*;
-
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public class ConfigureGradleEnterprise implements GradleEnterpriseListener {
-
     private static final String EXPERIMENT_DIR = System.getProperty("com.gradle.enterprise.build-validation.expDir");
 
-    private final RootProjectExtractor rootProjectExtractor;
-    private final Logger logger;
+    private final ConfigureDevelocityAdaptor configureDevelocityAdaptor;
 
     @Inject
-    public ConfigureGradleEnterprise(RootProjectExtractor rootProjectExtractor, Logger logger) {
-        this.rootProjectExtractor = rootProjectExtractor;
-        this.logger = logger;
+    public ConfigureGradleEnterprise(ConfigureDevelocityAdaptor configureDevelocityAdaptor) {
+        this.configureDevelocityAdaptor = configureDevelocityAdaptor;
     }
 
     @Override
     public void configure(GradleEnterpriseApi api, MavenSession session) {
-        logger.debug("Configuring build scan published event...");
-
-        BuildScanApi buildScan = api.getBuildScan();
-
-        String geUrl = System.getProperty("gradle.enterprise.url");
-        String geAllowUntrustedServer = System.getProperty("gradle.enterprise.allowUntrustedServer");
-
-        if (geUrl != null && !geUrl.isEmpty()) {
-            buildScan.setServer(geUrl);
-        }
-        if (geAllowUntrustedServer != null && !geAllowUntrustedServer.isEmpty()) {
-            buildScan.setAllowUntrustedServer(Boolean.parseBoolean(geAllowUntrustedServer));
-        }
-
-        String rootProjectName = rootProjectExtractor.extractRootProject(session).getName();
-
-        registerBuildScanActions(buildScan, rootProjectName);
-        configureBuildScanPublishing(buildScan);
+        configureDevelocityAdaptor.configure(new GradleEnterpriseApiAdapter(api), session);
     }
-
-    private static void registerBuildScanActions(BuildScanApi buildScan, String rootProjectName) {
-        buildScan.buildFinished(buildResult -> {
-            // communicate via error file that no GE server is set
-            boolean omitServerUrlValidation = parseBoolean(System.getProperty("com.gradle.enterprise.build-validation.omitServerUrlValidation"));
-            if (buildScan.getServer() == null && !omitServerUrlValidation) {
-                buildScan.publishAlwaysIf(false); // disable publishing, otherwise scans.gradle.com will be used
-                File errorFile = new File(EXPERIMENT_DIR, "errors.txt");
-                append(errorFile, "The Gradle Enterprise server URL has not been configured in the project or on the command line.");
-            }
-        });
-
-        buildScan.buildFinished(buildResult -> {
-            String expId = System.getProperty("com.gradle.enterprise.build-validation.expId");
-            addCustomValueAndSearchLink(buildScan, "Experiment id", expId);
-            buildScan.tag(expId);
-
-            String runId = System.getProperty("com.gradle.enterprise.build-validation.runId");
-            addCustomValueAndSearchLink(buildScan, "Experiment run id", runId);
-
-            String scriptsVersion = System.getProperty("com.gradle.enterprise.build-validation.scriptsVersion");
-            buildScan.value("Build validation scripts", scriptsVersion);
-        });
-
-        buildScan.buildScanPublished(scan -> {
-            String runNum = System.getProperty("com.gradle.enterprise.build-validation.runNum");
-            URI buildScanUri = scan.getBuildScanUri();
-            String buildScanId = scan.getBuildScanId();
-            String port = buildScanUri.getPort() != -1 ? ":" + buildScanUri.getPort() : "";
-            String baseUrl = String.format("%s://%s%s", buildScanUri.getScheme(), buildScanUri.getHost(), port);
-
-            File scanFile = new File(EXPERIMENT_DIR, "build-scans.csv");
-            append(scanFile, String.format("%s,%s,%s,%s,%s\n", runNum, rootProjectName, baseUrl, buildScanUri, buildScanId));
-        });
-    }
-
-    private static void configureBuildScanPublishing(BuildScanApi buildScan) {
-        buildScan.publishAlways();
-        buildScan.capture(t -> t.setGoalInputFiles(true)); // also set via sys prop
-        buildScan.setUploadInBackground(false);
-    }
-
-    private static void addCustomValueAndSearchLink(BuildScanApi buildScan, String label, String value) {
-        buildScan.value(label, value);
-        if (buildScan.getServer() != null) {
-            String server = buildScan.getServer();
-            String searchParams = "search.names=" + urlEncode(label) + "&search.values=" + urlEncode(value);
-            String url = appendIfMissing(server, "/") + "scans?" + searchParams + "#selection.buildScanB=" + urlEncode("{SCAN_ID}");
-            buildScan.link(label + " build scans", url);
-        }
-    }
-
-    private static String appendIfMissing(String str, String suffix) {
-        return str.endsWith(suffix) ? str : str + suffix;
-    }
-
-    private static String urlEncode(String str) {
-        try {
-            return URLEncoder.encode(str, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static void append(File file, String text) {
-        try {
-            Files.write(file.toPath(), text.getBytes(), CREATE, WRITE, APPEND);
-        } catch (IOException e) {
-            throw new RuntimeException(String.format("Unable to write to file %s: %s", file.getName(), e.getMessage()), e);
-        }
-    }
-
 }

--- a/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureGradleEnterprise.java
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureGradleEnterprise.java
@@ -1,15 +1,13 @@
 package com.gradle;
 
 import com.gradle.develocity.agent.maven.adapters.enterprise.GradleEnterpriseApiAdapter;
-import com.gradle.maven.extension.api.GradleEnterpriseApi;
-import com.gradle.maven.extension.api.GradleEnterpriseListener;
 import org.apache.maven.execution.MavenSession;
 
 import javax.inject.Inject;
 
-@SuppressWarnings({"unused", "deprecation"})
-public class ConfigureGradleEnterprise implements GradleEnterpriseListener {
-    private static final String EXPERIMENT_DIR = System.getProperty("com.gradle.enterprise.build-validation.expDir");
+// Using fully qualified class names to avoid deprecation warnings on import statements
+@SuppressWarnings({"deprecation"})
+public class ConfigureGradleEnterprise implements com.gradle.maven.extension.api.GradleEnterpriseListener {
 
     private final ConfigureDevelocityAdaptor configureDevelocityAdaptor;
 
@@ -19,7 +17,7 @@ public class ConfigureGradleEnterprise implements GradleEnterpriseListener {
     }
 
     @Override
-    public void configure(GradleEnterpriseApi api, MavenSession session) {
+    public void configure(com.gradle.maven.extension.api.GradleEnterpriseApi api, MavenSession session) {
         configureDevelocityAdaptor.configure(new GradleEnterpriseApiAdapter(api), session);
     }
 }

--- a/components/configure-gradle-enterprise-maven-extension/src/main/resources/META-INF/plexus/components.xml
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/resources/META-INF/plexus/components.xml
@@ -7,5 +7,12 @@
       <description>Configures Gradle Enterprise</description>
       <isolated-realm>false</isolated-realm>
     </component>
+    <component>
+      <role>com.gradle.develocity.agent.maven.api.DevelocityListener</role>
+      <role-hint>configure-develocity</role-hint>
+      <implementation>com.gradle.ConfigureDevelocity</implementation>
+      <description>Configures Develocity</description>
+      <isolated-realm>false</isolated-realm>
+    </component>
   </components>
 </component-set>

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly CONFIGURE_GRADLE_ENTERPRISE_CLASSPATH="${LIB_DIR}/maven-libs/configure-gradle-enterprise-maven-extension-${SCRIPT_VERSION}.jar:${LIB_DIR}/maven-libs/develocity-maven-extension-adapters-<EXTENSION_ADAPTERS_VERSION>.jar"
+readonly CONFIGURE_GRADLE_ENTERPRISE_JAR="${LIB_DIR}/maven-libs/configure-gradle-enterprise-maven-extension-${SCRIPT_VERSION}-all.jar"
 
 find_maven_executable() {
   if [ -f "./mvnw" ]; then
@@ -28,7 +28,7 @@ invoke_maven() {
   fi
 
   local extension_classpath
-  extension_classpath="${CONFIGURE_GRADLE_ENTERPRISE_CLASSPATH}"
+  extension_classpath="${CONFIGURE_GRADLE_ENTERPRISE_JAR}"
 
   if [ "$enable_ge" == "on" ]; then
     # Reset the extension classpath and add all of the jars in the lib/maven dir

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-readonly CONFIGURE_GRADLE_ENTERPRISE_JAR="${LIB_DIR}/maven-libs/configure-gradle-enterprise-maven-extension-${SCRIPT_VERSION}.jar"
+readonly CONFIGURE_GRADLE_ENTERPRISE_CLASSPATH="${LIB_DIR}/maven-libs/configure-gradle-enterprise-maven-extension-${SCRIPT_VERSION}.jar:${LIB_DIR}/maven-libs/develocity-maven-extension-adapters-<EXTENSION_ADAPTERS_VERSION>.jar"
 
 find_maven_executable() {
   if [ -f "./mvnw" ]; then
@@ -28,7 +28,7 @@ invoke_maven() {
   fi
 
   local extension_classpath
-  extension_classpath="${CONFIGURE_GRADLE_ENTERPRISE_JAR}"
+  extension_classpath="${CONFIGURE_GRADLE_ENTERPRISE_CLASSPATH}"
 
   if [ "$enable_ge" == "on" ]; then
     # Reset the extension classpath and add all of the jars in the lib/maven dir


### PR DESCRIPTION
The Gradle Enterprise Maven Extension was renamed to the Develocity Maven
Extension in version 1.21.  The API was also updated for hte product name
change. Unfortunately, this broke compatibility with the Build Validation
Scripts. This commit fixes the incompatibility.

The fix works by updating the configure-gradle-enterprise-maven-extension to
define and register two listeners: a GradleEnterpriseListener and a
DevelocityListener.  If an older version of the Gradle Enterprise Maven
Extension is used, it will load the GradleEnterpriseListener.  If a newer
version of the Develocity Maven Extension is used, then it will load the
DevelocityListener. The Develocity Maven Extension Adapters are used to
eliminate duplication between the two different listeners.

To ensure compatibility with older verisons of Maven, this PR also
updates the extension to be compiled against an earlier version of
maven-core.

