### PR TITLE
Move Maven jars to avoid any licensing confusion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,21 +52,22 @@ allprojects {
 }
 
 val argbash by configurations.creating
-val mavenComponents by configurations.creating
 val develocityComponents by configurations.creating {
     attributes.attribute(
         TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
         objects.named(TargetJvmEnvironment.STANDARD_JVM)
     )
 }
+val mavenComponents by configurations.creating
+val thirdPartyMavenComponents by configurations.creating
 val develocityMavenComponents by configurations.creating
 
 dependencies {
     argbash("argbash:argbash:2.10.0@zip")
-    mavenComponents(project(":configure-gradle-enterprise-maven-extension"))
-    mavenComponents("com.gradle:common-custom-user-data-maven-extension:1.13")
     develocityComponents("com.gradle:build-scan-summary:$buildScanSummaryVersion")
     develocityMavenComponents("com.gradle:gradle-enterprise-maven-extension:1.18.4")
+    mavenComponents(project(":configure-gradle-enterprise-maven-extension"))
+    thirdPartyMavenComponents("com.gradle:common-custom-user-data-maven-extension:1.13")
 }
 
 shellcheck {
@@ -213,6 +214,9 @@ val copyMavenScripts by tasks.registering(Copy::class) {
         into("lib/develocity/")
     }
     from(copyThirdPartyComponents) {
+        into("lib/third-party/")
+    }
+    from(thirdPartyMavenComponents) {
         into("lib/third-party/")
     }
     from(mavenComponents) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,19 +53,20 @@ allprojects {
 
 val argbash by configurations.creating
 val mavenComponents by configurations.creating
-val buildScanSummaryComponent by configurations.creating {
+val develocityComponents by configurations.creating {
     attributes.attribute(
         TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
         objects.named(TargetJvmEnvironment.STANDARD_JVM)
     )
 }
+val develocityMavenComponents by configurations.creating
 
 dependencies {
     argbash("argbash:argbash:2.10.0@zip")
     mavenComponents(project(":configure-gradle-enterprise-maven-extension"))
-    mavenComponents("com.gradle:gradle-enterprise-maven-extension:1.18.4")
     mavenComponents("com.gradle:common-custom-user-data-maven-extension:1.13")
-    buildScanSummaryComponent("com.gradle:build-scan-summary:$buildScanSummaryVersion")
+    develocityComponents("com.gradle:build-scan-summary:$buildScanSummaryVersion")
+    develocityMavenComponents("com.gradle:gradle-enterprise-maven-extension:1.18.4")
 }
 
 shellcheck {
@@ -74,13 +75,13 @@ shellcheck {
 }
 
 val copyDevelocityComponents by tasks.registering(Sync::class) {
-    from(buildScanSummaryComponent)
+    from(develocityComponents)
     into(project.layout.buildDirectory.dir("components/develocity"))
     include("build-scan-summary-$buildScanSummaryVersion.jar")
 }
 
 val copyThirdPartyComponents by tasks.registering(Sync::class) {
-    from(buildScanSummaryComponent)
+    from(develocityComponents)
     into(project.layout.buildDirectory.dir("components/third-party"))
     exclude("build-scan-summary-$buildScanSummaryVersion.jar")
 }
@@ -206,6 +207,9 @@ val copyMavenScripts by tasks.registering(Copy::class) {
         into("lib/scripts/")
     }
     from(copyDevelocityComponents) {
+        into("lib/develocity/")
+    }
+    from(develocityMavenComponents) {
         into("lib/develocity/")
     }
     from(copyThirdPartyComponents) {

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -10,7 +10,7 @@ find_versioned_jar() {
 
 CONFIGURE_GRADLE_ENTERPRISE_JAR="${LIB_DIR}/maven-libs/configure-gradle-enterprise-maven-extension-${SCRIPT_VERSION}.jar"
 GRADLE_ENTERPRISE_MAVEN_EXTENSION_JAR="$(find_versioned_jar "${SCRIPT_DIR}/lib/develocity" "gradle-enterprise-maven-extension")"
-COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION_JAR="$(find_versioned_jar "${LIB_DIR}/maven-libs" "common-custom-user-data-maven-extension")"
+COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION_JAR="$(find_versioned_jar "${SCRIPT_DIR}/lib/third-party" "common-custom-user-data-maven-extension")"
 readonly CONFIGURE_GRADLE_ENTERPRISE_JAR GRADLE_ENTERPRISE_MAVEN_EXTENSION_JAR COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION_JAR
 
 find_maven_executable() {

--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 
-readonly CONFIGURE_GRADLE_ENTERPRISE_JAR="${LIB_DIR}/maven-libs/configure-gradle-enterprise-maven-extension-${SCRIPT_VERSION}.jar"
+find_versioned_jar() {
+  lcoal dir_to_search base_name
+  dir_to_search="$1"
+  base_name="$2"
+
+  find "${dir_to_search}" -name "${base_name}*" -type f -print -quit
+}
+
+CONFIGURE_GRADLE_ENTERPRISE_JAR="${LIB_DIR}/maven-libs/configure-gradle-enterprise-maven-extension-${SCRIPT_VERSION}.jar"
+GRADLE_ENTERPRISE_MAVEN_EXTENSION_JAR="$(find_versioned_jar "${SCRIPT_DIR}/lib/develocity" "gradle-enterprise-maven-extension")"
+COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION_JAR="$(find_versioned_jar "${LIB_DIR}/maven-libs" "common-custom-user-data-maven-extension")"
+readonly CONFIGURE_GRADLE_ENTERPRISE_JAR GRADLE_ENTERPRISE_MAVEN_EXTENSION_JAR COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION_JAR
 
 find_maven_executable() {
   if [ -f "./mvnw" ]; then
@@ -31,19 +42,7 @@ invoke_maven() {
   extension_classpath="${CONFIGURE_GRADLE_ENTERPRISE_JAR}"
 
   if [ "$enable_ge" == "on" ]; then
-    # Reset the extension classpath and add all of the jars in the lib/maven dir
-    # The lib/maven dir includes:
-    #  - the Gradle Enterprise Maven extension
-    #  - the Common Custom User Data Maven extension
-    #  - the configure-gradle-enterprise Maven extension
-    extension_classpath=""
-    for jar in "${LIB_DIR}"/maven-libs/*; do
-      if [ "${extension_classpath}" == "" ]; then
-        extension_classpath="${jar}"
-      else
-        extension_classpath="${extension_classpath}:${jar}"
-      fi
-    done
+    extension_classpath="${extension_classpath}:${GRADLE_ENTERPRISE_MAVEN_EXTENSION_JAR}:${COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION_JAR}"
   fi
 
   if [ -n "${ge_server}" ]; then


### PR DESCRIPTION
- **Move the Develocity Maven extension to lib/develocity**.  It is covered by the Develocity terms of service.
- **Move common-custom-user-data-maven-extension to lib/third-party**.  From the perspective of this project, it is another third-party OSS dependency.

