### PR TITLE
Tested OS and Java versions are updated

### DIFF
--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -35,18 +35,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019]
-        java-version: [ '8', '11', '17' ]
+        # Only the latest available version of each OS is tested
+        # Both macOS 13 and 14 are tested because they use different architectures
+        os:
+          - ubuntu-24.04
+          - macos-13 # x86_64
+          - macos-14 # aarch64
+          - windows-2022
+        # Only LTS versions greater than 8 are tested
+        java-version: [ '8', '11', '17', '21' ]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             shell: bash
-          - os: ubuntu-22.04
+          - os: macos-13
             shell: bash
-          - os: macos-11
+          - os: macos-14
             shell: bash
-          - os: macos-12
-            shell: bash
-          - os: windows-2019
+          - os: windows-2022
             shell: wsl-bash
     defaults:
       run:
@@ -73,7 +78,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
+          distribution: ${{ matrix.os == 'macos-14' && 'zulu' || 'temurin' }} # No Temurin JDK 8 distribution for aarch64
       - name: Download built script artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: Vampire/setup-wsl@v3
         with:
-          distribution: Ubuntu-22.04
+          distribution: Ubuntu-24.04
           additional-packages: curl unzip wget apt-transport-https gnupg
       - name: Set up JDK ${{ matrix.java-version }} on WSL
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run Gradle Experiment 05
         run: |
           cd gradle-enterprise-gradle-build-validation
-          ./05-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/p4ghldkcscfwi -s https://ge.solutions-team.gradle.com -u https://ge.solutions-team.gradle.com/cache/
+          ./05-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/cemwsttqjhzhq -s https://ge.solutions-team.gradle.com -u https://ge.solutions-team.gradle.com/cache/
       - name: Run Maven Experiment 01
         run: |
           cd gradle-enterprise-maven-build-validation

--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -41,7 +41,7 @@ jobs:
           - ubuntu-24.04
           - macos-13 # x86_64
           - macos-14 # aarch64
-          - windows-2022
+          - windows-2019
         # Only LTS versions greater than 8 are tested
         java-version: [ '8', '11', '17', '21' ]
         include:
@@ -51,7 +51,7 @@ jobs:
             shell: bash
           - os: macos-14
             shell: bash
-          - os: windows-2022
+          - os: windows-2019
             shell: wsl-bash
     defaults:
       run:

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-24.04
           - macos-13 # x86_64
           - macos-14 # aarch64
-          - windows-2022
+          - windows-2019
         # Only LTS versions greater than 8 are tested
         java-version: [ '8', '11', '17', '21' ]
         include:
@@ -30,7 +30,7 @@ jobs:
             shell: bash
           - os: macos-14
             shell: bash
-          - os: windows-2022
+          - os: windows-2019
             shell: wsl-bash
     defaults:
       run:

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: Vampire/setup-wsl@v3
         with:
-          distribution: Ubuntu-22.04
+          distribution: Ubuntu-24.04
           additional-packages: curl unzip wget apt-transport-https gnupg
       - name: Set up JDK ${{ matrix.java-version }} on WSL
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run Gradle Experiment 05
         run: |
           cd gradle-enterprise-gradle-build-validation
-          ./05-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/p4ghldkcscfwi -s https://ge.solutions-team.gradle.com -u https://ge.solutions-team.gradle.com/cache/
+          ./05-validate-remote-build-caching-ci-local.sh -1 https://ge.solutions-team.gradle.com/s/cemwsttqjhzhq -s https://ge.solutions-team.gradle.com -u https://ge.solutions-team.gradle.com/cache/
       - name: Run Maven Experiment 01
         run: |
           cd gradle-enterprise-maven-build-validation

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -14,18 +14,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019]
-        java-version: [ '8', '11', '17' ]
+        # Only the latest available version of each OS is tested
+        # Both macOS 13 and 14 are tested because they use different architectures
+        os:
+          - ubuntu-24.04
+          - macos-13 # x86_64
+          - macos-14 # aarch64
+          - windows-2022
+        # Only LTS versions greater than 8 are tested
+        java-version: [ '8', '11', '17', '21' ]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             shell: bash
-          - os: ubuntu-22.04
+          - os: macos-13
             shell: bash
-          - os: macos-11
+          - os: macos-14
             shell: bash
-          - os: macos-12
-            shell: bash
-          - os: windows-2019
+          - os: windows-2022
             shell: wsl-bash
     defaults:
       run:
@@ -52,7 +57,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
+          distribution: ${{ matrix.os == 'macos-14' && 'zulu' || 'temurin' }} # No Temurin JDK 8 distribution for aarch64
       - name: Download and extract build validation Scripts
         run: |
           curl -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/development-latest/gradle-enterprise-gradle-build-validation-dev.zip


### PR DESCRIPTION
GitHub does not offer MacOS 11 runners anymore so those workflows are failing.

https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/10042207806

Supported versions are now 12, 13, & 14.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories

Additionally, the PR updates the versions of each tested OS to the latest and adds Java 21. 