### PR TITLE
Fixed CCUD CI detection when using wsl-bash on GHA

### DIFF
--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -58,7 +58,7 @@ jobs:
         shell: ${{ matrix.shell }} {0}
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
-      WSLENV: GRADLE_ENTERPRISE_ACCESS_KEY
+      WSLENV: GITHUB_ACTIONS:GITHUB_SERVER_URL:GITHUB_REPOSITORY:GITHUB_RUN_ID:GITHUB_WORKFLOW:GITHUB_HEAD_REF:GRADLE_ENTERPRISE_ACCESS_KEY
     steps:
       - name: Set up WSL
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -37,7 +37,7 @@ jobs:
         shell: ${{ matrix.shell }} {0}
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
-      WSLENV: GRADLE_ENTERPRISE_ACCESS_KEY
+      WSLENV: GITHUB_ACTIONS:GITHUB_SERVER_URL:GITHUB_REPOSITORY:GITHUB_RUN_ID:GITHUB_WORKFLOW:GITHUB_HEAD_REF:GRADLE_ENTERPRISE_ACCESS_KEY
     steps:
       - name: Set up WSL
         if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
Added the CCUD necessary env vars to the WSLENV for wsl-bash githubActions testing. 

Until now, cross-platform tests on windows, which use wsl-bash shell did not correctly pick up that this was executed on github actions. This is not an issue of CCUD, it's an issue of WSL, which by default doesn't "forward" env vars set in Windows (host) by default. The only way to forward them is to set them using `WSLENV` - see [discussion](https://github.com/Vampire/setup-wsl/discussions/9) and [Microsoft blog](https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/). You can also observe that in this [test project](https://github.com/ribafish/kotlinTests/actions/runs/10146123467), where the env vars are printed out. All of them are available with the [default windows shell (pwsh)](https://github.com/ribafish/kotlinTests/actions/runs/10146123467/job/28053822402#step:7:55), but almost none are there with [wsl](https://github.com/ribafish/kotlinTests/actions/runs/10146123467/job/28053822792#step:7:52). When [WSLENV is configured](https://github.com/ribafish/kotlinTests/actions/runs/10159960175/workflow#L28), the [specified vars are available](https://github.com/ribafish/kotlinTests/actions/runs/10159960175/job/28095278023#step:7:59), which also means that [CCUD will tag the build](https://ge.solutions-team.gradle.com/s/t7646azizh7qq#info) correctly, as well as add all of the [other values](https://ge.solutions-team.gradle.com/s/t7646azizh7qq/custom-values#L0-L1).

Note: These are the two cross-platform runs with these changes:
1. [Run Cross-Platform Tests (Use Development Release)](https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/10160172435) - [Example scan with custom data](https://ge.solutions-team.gradle.com/s/aazeyjjh5ojxk)
2. [Run Cross-Platform Tests (Build From Source)](https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/runs/10160174186) - [Example scan with custom data](https://ge.solutions-team.gradle.com/s/xsu3djvonfqnu)