### PR TITLE
Fix for #644, allow configuration of artifact name for `Archive receipt` step

### DIFF
--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -29,6 +29,10 @@ inputs:
   enableGradleEnterprise:
     description: "Enables Gradle Enterprise on a project not already connected"
     required: false
+  archiveRecieptArtifactName:
+    description: "The artifact name for the archive step"
+    default: "experiment-1-receipt"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -110,5 +114,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt
+        name: ${{ inputs.archiveReceiptArtifactName }}
         path: gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -32,6 +32,10 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
+  archiveRecieptArtifactName:
+    description: "The artifact name for the archive step"
+    default: "experiment-2-receipt"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -118,5 +122,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt
+        name: ${{ inputs.archiveReceiptArtifactName }}
         path: gradle-enterprise-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -32,6 +32,10 @@ inputs:
   failIfNotFullyCacheable:
     description: "Terminates with exit code 3 if the build is not fully cacheable"
     required: false
+  archiveRecieptArtifactName:
+    description: "The artifact name for the archive step"
+    default: "experiment-3-receipt"
+    required: false
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
@@ -118,5 +122,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-3-receipt
+        name: ${{ inputs.archiveReceiptArtifactName }}
         path: gradle-enterprise-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt


### PR DESCRIPTION
To ensure the `Archive receipt` step works when run in a matrixed workflow, the artifact name needs to be unique.

This change adds an input to the action for the artifact name `archieveReceiptArtifactName` and defaults to the previous hardcoded value. This allows callers to specify the name if needed. 

In our usecase, we run this in a matrixed workflow against 8 apps, so we can ensure the name is different by appending the app name to the artifact name like:

```
- name: Run experiment 1
  uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
  env:
    DEVELOCITY_ACCESS_KEY: xxxxxx
  with:
    gitRepo: ${{ env.GIT_REPO }}
    gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
    tasks: ${{ env.TASKS }}
    projectDir: ${{ matrix.target.project }}
    archiveReceiptArtifactName: "experiment-1-receipt-${{ matrix.target.project }}"
```

