### PR TITLE
Use unique artifact identifier in upload-artifact step

### DIFF
--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -110,5 +110,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
+        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -110,5 +110,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-1-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -110,5 +110,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt
+        name: experiment-1-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -108,7 +108,13 @@ runs:
         cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
       shell: bash
     - name: Archive receipt
+      id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt
+    - name: Add artifact link to summary
+      run: |
+        echo "-------------" >> $GITHUB_STEP_SUMMARY
+        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -110,5 +110,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -110,5 +110,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
+        name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-2-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt
+        name: experiment-2-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -116,7 +116,13 @@ runs:
         cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
       shell: bash
     - name: Archive receipt
+      id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt
+    - name: Add artifact link to summary
+      run: |
+        echo "-------------" >> $GITHUB_STEP_SUMMARY
+        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
+        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
+        name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-3-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-3-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-3-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-3-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-3-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
+        name: experiment-3-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -116,7 +116,13 @@ runs:
         cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
       shell: bash
     - name: Archive receipt
+      id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
         name: experiment-3-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt
+    - name: Add artifact link to summary
+      run: |
+        echo "-------------" >> $GITHUB_STEP_SUMMARY
+        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-3-receipt
+        name: experiment-3-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-3-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
+        name: experiment-3-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
         path: gradle-enterprise-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
+        name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest*/exp1-*.receipt

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-1-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
         path: gradle-enterprise-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest*/exp1-*.receipt

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt
+        name: experiment-1-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest*/exp1-*.receipt

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest*/exp1-*.receipt

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -116,7 +116,13 @@ runs:
         cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
       shell: bash
     - name: Archive receipt
+      id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest*/exp1-*.receipt
+    - name: Add artifact link to summary
+      run: |
+        echo "-------------" >> $GITHUB_STEP_SUMMARY
+        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-1-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
+        name: experiment-1-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
         path: gradle-enterprise-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest*/exp1-*.receipt

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -116,7 +116,13 @@ runs:
         cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
       shell: bash
     - name: Archive receipt
+      id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest*/exp2-*.receipt
+    - name: Add artifact link to summary
+      run: |
+        echo "-------------" >> $GITHUB_STEP_SUMMARY
+        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-2-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
         path: gradle-enterprise-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest*/exp2-*.receipt

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.job }}${{ strategy.job-index && format('-{}', strategy.job-index) || '' }}
+        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
         path: gradle-enterprise-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest*/exp2-*.receipt

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
+        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest*/exp2-*.receipt

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt
+        name: experiment-2-receipt-${{ github.run_id }}-${{github.run_number}}-${{ github.job }}-${{ strategy.job-index || '0' }}-${{ strategy.job-total || '0' }}
         path: gradle-enterprise-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest*/exp2-*.receipt

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -118,5 +118,5 @@ runs:
     - name: Archive receipt
       uses: actions/upload-artifact@v4
       with:
-        name: experiment-2-receipt-${{ github.job }}-${{ strategy.job-index || '0' }}
+        name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: gradle-enterprise-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest*/exp2-*.receipt


### PR DESCRIPTION
### Issue
Fixes https://github.com/gradle/gradle-enterprise-build-validation-scripts/issues/644

Since [upload-artifact@v4](https://github.com/actions/upload-artifact), uploading again the same artifact name in a workflow fails the step.
Using a hardcoded `experiment-X-receipt` is not valid anymore

### Fix
Use a unique name. This is not so straightforward as some collisions can occur in the case of matrix.
Using the `job-index` for matrix solves this.
Note that appending the `job-index` is happening only if `job-total > 1` to not suffix artifacts from non matrix scenario

This could hopefully get simplified if/when GitHub starts to expose a unique `job-id` when running with matrix strategy.

### Extra
A receipt download link has been added as part of the workflow summary

### Example
See a summary running with the PR fix [here](https://github.com/jprinet/matrix-workflow-test/actions/runs/10268393419)
