### PR TITLE
Gradle Enterprise deprecation warnings aren't printed to the console for Maven builds using Develocity extension

### DIFF
--- a/components/scripts/lib/maven.sh
+++ b/components/scripts/lib/maven.sh
@@ -46,8 +46,12 @@ invoke_maven() {
   fi
 
   if [ -n "${ge_server}" ]; then
-    args+=("-Dgradle.enterprise.url=${ge_server}")
-    args+=("-Dgradle.enterprise.allowUntrustedServer=false")
+    args+=(
+      -Dgradle.enterprise.url="${ge_server}"
+      -Dgradle.enterprise.allowUntrustedServer=false
+      -Ddevelocity.url="${ge_server}"
+      -Ddevelocity.allowUntrustedServer=false
+    )
   fi
 
   args+=(
@@ -58,6 +62,7 @@ invoke_maven() {
     -Dcom.gradle.enterprise.build-validation.runNum="${run_num}"
     -Dcom.gradle.enterprise.build-validation.scriptsVersion="${SCRIPT_VERSION}"
     -Dgradle.scan.captureGoalInputFiles=true
+    -Ddevelocity.scan.captureFileFingerprints=true
     -Dpts.enabled=false
   )
 

--- a/components/scripts/maven/01-validate-local-build-caching-same-location.sh
+++ b/components/scripts/maven/01-validate-local-build-caching-same-location.sh
@@ -136,8 +136,12 @@ execute_build() {
   invoke_maven "${run_num}" \
      -Dgradle.cache.local.enabled=true \
      -Dgradle.cache.local.storeEnabled=true \
-     -Dgradle.cache.remote.enabled=false \
      -Dgradle.cache.local.directory="${BUILD_CACHE_DIR}" \
+     -Dgradle.cache.remote.enabled=false \
+     -Ddevelocity.cache.local.enabled=true \
+     -Ddevelocity.cache.local.storeEnabled=true \
+     -Ddevelocity.cache.local.directory="${BUILD_CACHE_DIR}" \
+     -Ddevelocity.cache.remote.enabled=false \
      clean ${tasks}
 }
 

--- a/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
+++ b/components/scripts/maven/02-validate-local-build-caching-different-locations.sh
@@ -140,8 +140,12 @@ execute_build() {
   invoke_maven "${run_num}" \
      -Dgradle.cache.local.enabled=true \
      -Dgradle.cache.local.storeEnabled=true \
-     -Dgradle.cache.remote.enabled=false \
      -Dgradle.cache.local.directory="${BUILD_CACHE_DIR}" \
+     -Dgradle.cache.remote.enabled=false \
+     -Ddevelocity.cache.local.enabled=true \
+     -Ddevelocity.cache.local.storeEnabled=true \
+     -Ddevelocity.cache.local.directory="${BUILD_CACHE_DIR}" \
+     -Ddevelocity.cache.remote.enabled=false \
      clean ${tasks}
 }
 

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -193,9 +193,17 @@ validate_build_config() {
 
 execute_build() {
   local args
-  args=(-Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=true)
+  args=(
+    -Dgradle.cache.local.enabled=false
+    -Dgradle.cache.remote.enabled=true
+    -Ddevelocity.cache.local.enabled=false
+    -Ddevelocity.cache.remote.enabled=true
+  )
   if [ -n "${remote_build_cache_url}" ]; then
-    args+=("-Dgradle.cache.remote.url=${remote_build_cache_url}")
+    args+=(
+      -Dgradle.cache.remote.url="${remote_build_cache_url}"
+      -Ddevelocity.cache.remote.url="${remote_build_cache_url}"
+    )
   fi
 
   # shellcheck disable=SC2206  # we want tasks to expand with word splitting in this case

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
 - [NEW] Predictive Test Selection is disabled when running builds
+- [FIX] Gradle Enterprise deprecation warnings are printed to the console for Maven builds using Develocity extension


### PR DESCRIPTION
This PR adds the equivalent DV extension system property where the legacy GE extension system properties were used. This results in no deprecation warnings printed to the console, while retaining backwards compatibility.

Ran the below tests and verified no deprecation warnings were printed.

```shell
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c feb731de5b279d3a941f81fb3d1845ec0405388b -g 'verify' -s https://ge.solutions-team.gradle.com
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c feb731de5b279d3a941f81fb3d1845ec0405388b -g 'verify' -e -s https://ge.solutions-team.gradle.com
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c 278d56ea8424de31758c1d05c16b9ea642466f1f -g 'verify' -s https://ge.solutions-team.gradle.com
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c 278d56ea8424de31758c1d05c16b9ea642466f1f -g 'verify' -e -s https://ge.solutions-team.gradle.com
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/dv-solutions.git -p sample-projects/maven/3.9.x/no-dv -g 'verify' -e -s https://ge.solutions-team.gradle.com
./01-validate-local-build-caching-same-location.sh -r git@github.com:gradle/dv-solutions.git -c 97c095e473c0deec4ec5a6847221dcee064c19d7 -p sample-projects/maven/3.9.x/no-dv -g 'verify' -e -s https://ge.solutions-team.gradle.com

./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c feb731de5b279d3a941f81fb3d1845ec0405388b -g 'verify' -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c feb731de5b279d3a941f81fb3d1845ec0405388b -g 'verify' -e -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c 278d56ea8424de31758c1d05c16b9ea642466f1f -g 'verify' -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/maven-build-scan-quickstart.git -c 278d56ea8424de31758c1d05c16b9ea642466f1f -g 'verify' -e -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/dv-solutions.git -p sample-projects/maven/3.9.x/no-dv -g 'verify' -e -s https://ge.solutions-team.gradle.com
./02-validate-local-build-caching-different-locations.sh -r git@github.com:gradle/dv-solutions.git -c 97c095e473c0deec4ec5a6847221dcee064c19d7 -p sample-projects/maven/3.9.x/no-dv -g 'verify' -e -s https://ge.solutions-team.gradle.com
```