### PR TITLE
Listeners in bundled Maven extension are cleaned up and aligned with other Solutions repos

### DIFF
--- a/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
+++ b/components/configure-gradle-enterprise-maven-extension/build.gradle.kts
@@ -9,7 +9,6 @@ repositories {
 
 dependencies {
     compileOnly("org.apache.maven:maven-core:3.6.3")  // intentionally compiling against an older version to preserve compatibility with older versions of Maven
-    compileOnly("org.codehaus.plexus:plexus-component-annotations:2.2.0")
     compileOnly("com.gradle:develocity-maven-extension:1.22.1")
     implementation("com.gradle:develocity-maven-extension-adapters:1.0")
 }

--- a/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocityListener.java
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureDevelocityListener.java
@@ -7,12 +7,12 @@ import org.apache.maven.execution.MavenSession;
 
 import javax.inject.Inject;
 
-public class ConfigureDevelocity implements DevelocityListener {
+public class ConfigureDevelocityListener implements DevelocityListener {
 
     private final ConfigureDevelocityAdaptor configureDevelocityAdaptor;
 
     @Inject
-    public ConfigureDevelocity(ConfigureDevelocityAdaptor configureDevelocityAdaptor, RootProjectExtractor rootProjectExtractor) {
+    public ConfigureDevelocityListener(ConfigureDevelocityAdaptor configureDevelocityAdaptor) {
         this.configureDevelocityAdaptor = configureDevelocityAdaptor;
     }
 
@@ -20,4 +20,5 @@ public class ConfigureDevelocity implements DevelocityListener {
     public void configure(DevelocityApi api, MavenSession session) {
         configureDevelocityAdaptor.configure(new DevelocityApiAdapter(api), session);
     }
+
 }

--- a/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureGradleEnterpriseListener.java
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/java/com/gradle/ConfigureGradleEnterpriseListener.java
@@ -6,13 +6,13 @@ import org.apache.maven.execution.MavenSession;
 import javax.inject.Inject;
 
 // Using fully qualified class names to avoid deprecation warnings on import statements
-@SuppressWarnings({"deprecation"})
-public class ConfigureGradleEnterprise implements com.gradle.maven.extension.api.GradleEnterpriseListener {
+@SuppressWarnings("deprecation")
+public class ConfigureGradleEnterpriseListener implements com.gradle.maven.extension.api.GradleEnterpriseListener {
 
     private final ConfigureDevelocityAdaptor configureDevelocityAdaptor;
 
     @Inject
-    public ConfigureGradleEnterprise(ConfigureDevelocityAdaptor configureDevelocityAdaptor) {
+    public ConfigureGradleEnterpriseListener(ConfigureDevelocityAdaptor configureDevelocityAdaptor) {
         this.configureDevelocityAdaptor = configureDevelocityAdaptor;
     }
 
@@ -20,4 +20,5 @@ public class ConfigureGradleEnterprise implements com.gradle.maven.extension.api
     public void configure(com.gradle.maven.extension.api.GradleEnterpriseApi api, MavenSession session) {
         configureDevelocityAdaptor.configure(new GradleEnterpriseApiAdapter(api), session);
     }
+
 }

--- a/components/configure-gradle-enterprise-maven-extension/src/main/resources/META-INF/plexus/components.xml
+++ b/components/configure-gradle-enterprise-maven-extension/src/main/resources/META-INF/plexus/components.xml
@@ -1,17 +1,18 @@
 <component-set>
   <components>
     <component>
+      <!--suppress DeprecatedClassUsageInspection -->
       <role>com.gradle.maven.extension.api.GradleEnterpriseListener</role>
-      <role-hint>configure-gradle-enterprise</role-hint>
-      <implementation>com.gradle.ConfigureGradleEnterprise</implementation>
-      <description>Configures Gradle Enterprise</description>
+      <role-hint>configure-gradle-enterprise-listener</role-hint>
+      <implementation>com.gradle.ConfigureGradleEnterpriseListener</implementation>
+      <description>Configures the Gradle Enterprise Maven extension</description>
       <isolated-realm>false</isolated-realm>
     </component>
     <component>
       <role>com.gradle.develocity.agent.maven.api.DevelocityListener</role>
-      <role-hint>configure-develocity</role-hint>
-      <implementation>com.gradle.ConfigureDevelocity</implementation>
-      <description>Configures Develocity</description>
+      <role-hint>configure-develocity-listener</role-hint>
+      <implementation>com.gradle.ConfigureDevelocityListener</implementation>
+      <description>Configures the Develocity Maven extension</description>
       <isolated-realm>false</isolated-realm>
     </component>
   </components>


### PR DESCRIPTION
This PR renames `ConfigureDevelocity` to `ConfigureDevelocityListener` and `ConfigureGradleEnterprise` to `ConfigureGradleEnterpriseListener` to better align with how listeners are named in other repositories. For example:

![image](https://github.com/user-attachments/assets/c2cdb9c3-5820-4291-a919-9f9dbc14c1d9)

Some other minor adjustments were made also.

