### PR TITLE
Added a README section on using GitHub Actions to run experiments with a private repo

### DIFF
--- a/.github/actions/gradle/README.md
+++ b/.github/actions/gradle/README.md
@@ -43,6 +43,42 @@ steps:
 Once the workflow has been triggered and finishes executing, you can navigate to the workflow's output and investigate
 the summary produced by the build validation scripts.
 
+#### Usage with private repository
+
+If the project is a private repository, you can leverage the checkout action to get a local checkout and pass that as the `gitRepo` input to the experiment actions.
+
+```yaml
+name: Run Build Validation Scripts
+
+on: [ workflow_dispatch ]
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: project-to-validate # check out the project to a subdirectory
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Download latest version of the validation scripts
+        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run experiment 3
+        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}"
+        with:
+          gitRepo: "file://$GITHUB_WORKSPACE/project-to-validate" # use the local checkout
+          tasks: build
+```
+
 ## Configuration cache compatibility
 
 Composite actions that will simplify validating Configuration Cache compatibility 

--- a/.github/actions/maven/README.md
+++ b/.github/actions/maven/README.md
@@ -35,3 +35,38 @@ steps:
 
 Once the workflow has been triggered and finishes executing, you can navigate to the workflow's output and investigate
 the summary produced by the build validation scripts.
+
+#### Usage with private repository
+
+If the project is a private repository, you can leverage the checkout action to get a local checkout and pass that as the `gitRepo` input to the experiment actions.
+
+```yaml
+name: Run Build Validation Scripts
+
+on: [ workflow_dispatch ]
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: project-to-validate # check out the project to a subdirectory
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+      - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run experiment 2
+        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-2@actions-stable
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}"
+        with:
+          gitRepo: "file://$GITHUB_WORKSPACE/project-to-validate" # use the local checkout
+          goals: package
+```


### PR DESCRIPTION
Added a README section on using GitHub Actions to run experiments with a private repo. It leverages the github actions checkout and passes that as a local git repo to the experiment actions. 

This is needed as the scripts themselves are using git clone command, which will fail with a private repo since access is not configured in the env by default. This should fix errors like below, as well as explains how to do it where it's expected (instead of searching for this by [issues](https://github.com/gradle/gradle-enterprise-build-validation-scripts/issues/421#issuecomment-1526934876))

```
Run gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
Run # Read the action inputs

Cloning private-gha-tests
Cloning into '/home/runner/work/private-gha-tests/private-gha-tests/gradle-enterprise-gradle-build-validation/.data/01-validate-incremental-building/20240920T092821-66ed4035/build_private-gha-tests'...
fatal: could not read Username for 'https://github.com/': No such device or address
ERROR: Unable to clone git repository https://github.com/ribafish/private-gha-tests
Error: Process completed with exit code 100.
```