### PR TITLE
Common Develocity injection script is used when setting Develocity server URL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,7 @@ val develocityMavenComponents by configurations.creating
 
 dependencies {
     argbash("argbash:argbash:2.10.0@zip")
-    develocityInjection("com.gradle:develocity-injection:1.0")
+    develocityInjection("com.gradle:develocity-injection:1.1")
     develocityComponents("com.gradle:build-scan-summary:$buildScanSummaryVersion")
     develocityMavenComponents("com.gradle:gradle-enterprise-maven-extension:1.18.4")
     mavenComponents(project(path = ":configure-gradle-enterprise-maven-extension", configuration = "shadow"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,9 +68,12 @@ allprojects {
 }
 
 val argbash by configurations.creating
-val develocityInjection = configurations.dependencyScope("develocityInjection").get()
+val develocityInjection = configurations.dependencyScope("develocityInjection") {
+    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named("develocity-injection-script"))
+}.get()
 val develocityInjectionResolvable = configurations.resolvable("${develocityInjection.name}Resolvable") {
     extendsFrom(develocityInjection)
+    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named("develocity-injection-script"))
 }
 val develocityComponents by configurations.creating {
     attributes.attribute(

--- a/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
@@ -17,9 +17,6 @@ def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
 def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
 def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
 
-def develocityUrl = getInputParam('develocity.build-validation.url')
-def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.build-validation.allow-untrusted-server'))
-
 def expDir = getInputParam('develocity.build-validation.expDir')
 def expId = getInputParam('develocity.build-validation.expId')
 def runId = getInputParam('develocity.build-validation.runId')
@@ -113,12 +110,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                 // only execute if Develocity plugin isn't applied
                 if (pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) return
-
-                if (develocityUrl) {
-                    buildScan.server = develocityUrl
-                    buildScan.allowUntrustedServer = develocityAllowUntrustedServer
-                }
-
                 if (!buildScan.server) {
                     failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/legacy#gradle_5_x_2')
                 }
@@ -129,11 +120,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             }
 
             pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                if (develocityUrl) {
-                    develocity.server = develocityUrl
-                    develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                }
-
                 if (!develocity.server.present) {
                     develocity.buildScan.publishing.onlyIf { false } // prevent publishing to scans.gradle.com
                     failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/current/#connecting_to_develocity')
@@ -157,12 +143,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         settings.pluginManager.withPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) {
             // only execute if Develocity plugin isn't applied
             if (settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) return
-
-            if (develocityUrl) {
-                settings.gradleEnterprise.server = develocityUrl
-                settings.gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
-            }
-
             if (!settings.gradleEnterprise.server) {
                 failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/legacy/#gradle_6_x_and_later_2')
             }
@@ -173,11 +153,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         }
 
         settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-            if (develocityUrl) {
-                settings.develocity.server = develocityUrl
-                settings.develocity.allowUntrustedServer = develocityAllowUntrustedServer
-            }
-
             if (!settings.develocity.server.present) {
                 settings.develocity.buildScan.publishing.onlyIf { false } // prevent publishing to scans.gradle.com
                 failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/current/#connecting_to_develocity')

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -29,8 +29,9 @@ invoke_gradle() {
 
   if [ -n "${ge_server}" ]; then
     args+=(
-      -Ddevelocity.build-validation.url="${ge_server}"
-      -Ddevelocity.build-validation.allow-untrusted-server=false
+      -Ddevelocity.url="${ge_server}"
+      -Ddevelocity.enforce-url=true
+      -Ddevelocity.allow-untrusted-server=false
     )
   fi
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,3 +29,12 @@ rootProject.name = "build-validation-scripts"
 include("components/configure-gradle-enterprise-maven-extension")
 
 project(":components/configure-gradle-enterprise-maven-extension").name = "configure-gradle-enterprise-maven-extension"
+
+val develocityCiInjectionProjectDir = providers.gradleProperty("develocityCiInjectionProjectDir")
+if (develocityCiInjectionProjectDir.isPresent) {
+    includeBuild(develocityCiInjectionProjectDir) {
+        dependencySubstitution {
+            substitute(module("com.gradle:develocity-injection")).using(project(":"))
+        }
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Will be merged when common Develocity injection script 1.1 is released.
> 
> Draft because gradle/develocity-ci-injection#10 must be merged and released before this can be merged. Changes could be required in the other PR causing updates to be required here.

This PR updates removes setting the server URL from the `configure-build-validation.gradle` script. This PR assumes gradle/develocity-ci-injection#10 will be merged.

It also adds the necessary configuration for the Develocity CI injection repository to be used as an included build:

```shell
./gradlew -PdevelocityCiInjectionProjectDir="../develocity-ci-injection" clean assemble
```

If `develocityCiInjectionProjectDir` isn't provided the script is resolved using Gradle dependency management. 
