### PR TITLE
Command line argument `-x` is removed from help text

### DIFF
--- a/components/scripts/lib/cli-parsers/gradle/01-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/01-cli-parser.m4
@@ -28,7 +28,6 @@ function print_help() {
   print_option_usage -a
   print_option_usage -s
   print_option_usage -e
-  print_option_usage -x
   print_option_usage -v
   print_option_usage -h
 }

--- a/components/scripts/lib/cli-parsers/gradle/02-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/02-cli-parser.m4
@@ -28,7 +28,6 @@ function print_help() {
   print_option_usage -a
   print_option_usage -s
   print_option_usage -e
-  print_option_usage -x
   print_option_usage -f
   print_option_usage -v
   print_option_usage -h

--- a/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/gradle/03-cli-parser.m4
@@ -28,7 +28,6 @@ function print_help() {
   print_option_usage -a
   print_option_usage -s
   print_option_usage -e
-  print_option_usage -x
   print_option_usage -f
   print_option_usage -v
   print_option_usage -h

--- a/components/scripts/lib/cli-parsers/maven/01-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/maven/01-cli-parser.m4
@@ -27,7 +27,6 @@ function print_help() {
   print_option_usage -a
   print_option_usage -s
   print_option_usage -e
-  print_option_usage -x
   print_option_usage -f
   print_option_usage -v
   print_option_usage -h

--- a/components/scripts/lib/cli-parsers/maven/02-cli-parser.m4
+++ b/components/scripts/lib/cli-parsers/maven/02-cli-parser.m4
@@ -27,7 +27,6 @@ function print_help() {
   print_option_usage -a
   print_option_usage -s
   print_option_usage -e
-  print_option_usage -x
   print_option_usage -f
   print_option_usage -v
   print_option_usage -h


### PR DESCRIPTION
This PR removes the `-x` argument from text displayed by `--help`.

![image](https://github.com/user-attachments/assets/72625ad1-d215-439a-9bda-5dd6624bd5f4)

