### PR TITLE
Use environment variables to configure Gradle init scripts

### DIFF
--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -194,19 +194,18 @@ validate_build_config() {
 }
 
 execute_build() {
-  local args
-  args=(--build-cache --init-script "${INIT_SCRIPTS_DIR}/configure-remote-build-caching.gradle")
-  if [ -n "${remote_build_cache_url}" ]; then
-    args+=("-Ddevelocity.build-validation.remoteBuildCacheUrl=${remote_build_cache_url}")
-  fi
-
-  # shellcheck disable=SC2206  # we want tasks to expand with word splitting in this case
-  args+=(clean ${tasks})
-
   info "Running build:"
-  info "./gradlew --build-cache -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} -Dpts.enabled=false clean ${tasks}$(print_extra_args)"
+  print_gradle_command
 
-  invoke_gradle 1 "${args[@]}"
+  # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
+  invoke_gradle 1 \
+     --build-cache \
+     --init-script "${INIT_SCRIPTS_DIR}/configure-remote-build-caching.gradle" \
+     clean ${tasks}
+}
+
+print_gradle_command() {
+  info "./gradlew --build-cache -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} -Dpts.enabled=false clean ${tasks}$(print_extra_args)"
 }
 
 # Overrides summary.sh#print_experiment_specific_summary_info

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 invoke_gradle() {
-  local run_num args
-  args=()
+  local run_num
   run_num=$1
   shift
 
@@ -12,35 +11,45 @@ invoke_gradle() {
     cd "${project_dir}" > /dev/null 2>&1 || die "ERROR: Subdirectory ${project_dir} (set with --project-dir) does not exist in ${project_name}" "${INVALID_INPUT}"
   fi
 
-  args+=(
-    --init-script "${INIT_SCRIPTS_DIR}/develocity-injection.gradle"
-    --init-script "${INIT_SCRIPTS_DIR}/configure-build-validation.gradle"
-    -Ddevelocity.injection.init-script-name=develocity-injection.gradle
-    -Ddevelocity.injection-enabled=true
+  envs+=(
+    DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=develocity-injection.gradle
+    DEVELOCITY_INJECTION_ENABLED=true
   )
 
   if [ "$enable_ge" == "on" ]; then
-    args+=(
-      -Dgradle.plugin-repository.url=https://plugins.gradle.org/m2
-      -Ddevelocity.plugin.version="3.14.1"
-      -Ddevelocity.ccud.plugin.version="2.0.2"
+    envs+=(
+      GRADLE_PLUGIN_REPOSITORY_URL=https://plugins.gradle.org/m2
+      DEVELOCITY_PLUGIN_VERSION="3.14.1"
+      DEVELOCITY_CCUD_PLUGIN_VERSION="2.0.2"
     )
   fi
 
   if [ -n "${ge_server}" ]; then
-    args+=(
-      -Ddevelocity.build-validation.url="${ge_server}"
-      -Ddevelocity.build-validation.allow-untrusted-server=false
+    envs+=(
+      DEVELOCITY_BUILD_VALIDATION_URL="${ge_server}"
+      DEVELOCITY_BUILD_VALIDATION_ALLOW_UNTRUSTED_SERVER=false
     )
   fi
 
-  args+=(
-    -Ddevelocity.build-validation.expDir="${EXP_DIR}"
-    -Ddevelocity.build-validation.expId="${EXP_SCAN_TAG}"
-    -Ddevelocity.build-validation.runId="${RUN_ID}"
-    -Ddevelocity.build-validation.runNum="${run_num}"
-    -Ddevelocity.build-validation.scriptsVersion="${SCRIPT_VERSION}"
-    -Ddevelocity.capture-file-fingerprints=true
+  if [ -n "${remote_build_cache_url}" ]; then
+    envs+=(
+      DEVELOCITY_BUILD_VALIDATION_REMOTEBUILDCACHEURL="${remote_build_cache_url}"
+    )
+  fi
+
+  envs+=(
+    DEVELOCITY_BUILD_VALIDATION_EXPDIR="${EXP_DIR}"
+    DEVELOCITY_BUILD_VALIDATION_EXPID="${EXP_SCAN_TAG}"
+    DEVELOCITY_BUILD_VALIDATION_RUNID="${RUN_ID}"
+    DEVELOCITY_BUILD_VALIDATION_RUNNUM="${run_num}"
+    DEVELOCITY_BUILD_VALIDATION_SCRIPTSVERSION="${SCRIPT_VERSION}"
+    DEVELOCITY_CAPTURE_FILE_FINGERPRINTS=true
+  )
+
+  local args
+  args=(
+    --init-script "${INIT_SCRIPTS_DIR}/develocity-injection.gradle"
+    --init-script "${INIT_SCRIPTS_DIR}/configure-build-validation.gradle"
     -Dpts.enabled=false
   )
 
@@ -57,9 +66,13 @@ invoke_gradle() {
   rm -f "${EXP_DIR}/errors.txt"
 
   debug "Current directory: $(pwd)"
-  debug ./gradlew "${args[@]}"
+  # shellcheck disable=SC2145
+  debug export "${envs[@]}"';' ./gradlew "${args[@]}"
 
-  if ./gradlew "${args[@]}"; then
+  # The parenthesis below will intentionally create a subshell. This causes the
+  # environment variables to only be exported for the child process and not leak
+  # to the rest of the script.
+  if (export "${envs[@]}"; ./gradlew "${args[@]}"); then
       build_outcomes+=("SUCCESSFUL")
   else
       build_outcomes+=("FAILED")

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 invoke_gradle() {
-  local run_num
+  local run_num envs
+  envs=()
   run_num=$1
   shift
 

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,4 +1,4 @@
 > [!IMPORTANT]
 > The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
 
-- [NEW] TBD
+- [FIX] Scripts fail for Gradle 7.0.2 and older under certain conditions


### PR DESCRIPTION
System properties cannot be read reliably from init scripts for older versions of Gradle. This is not the case for environment variables. This PR changes the configuration of the init scripts to be done using environment variables instead of system properties. 