### PR TITLE
Environment variable changes are reverted and `gradle.startParameter` is used to read system properties in init scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -167,6 +167,7 @@ val copyGradleScripts by tasks.registering(Sync::class) {
     from(develocityInjectionResolvable) {
         rename { "develocity-injection.gradle" }
         into("lib/scripts/gradle-init-scripts")
+        filter(TransformDevelocityInjectionScript())
     }
     from(layout.projectDirectory.dir("components/scripts")) {
         include("README.md")

--- a/buildSrc/src/main/kotlin/TransformDevelocityInjectionScript.kt
+++ b/buildSrc/src/main/kotlin/TransformDevelocityInjectionScript.kt
@@ -1,0 +1,27 @@
+/*
+ * Transforms usages of 'System.getProperty' in the Develocity injection script
+ * to 'gradle.startParameter'. This is required because 'System.getProperty'
+ * cannot be used to reliably read system properties from init scripts in Gradle
+ * 7.0.2 and earlier.
+*/
+class TransformDevelocityInjectionScript : (String) -> String {
+
+    override fun invoke(content: String): String {
+        return content
+            .replace("static getInputParam(String name) {", "def getInputParam = { String name ->")
+            .replace("System.getProperty(name)", "gradle.startParameter.systemPropertiesArgs[name]")
+
+            // The 'getInputParam' method is no longer static so it must be redefined within the
+            // 'enableDevelocityInjection' method
+            .replace("void enableDevelocityInjection() {", """
+            void enableDevelocityInjection() {
+                def getInputParam = { String name ->
+                    def ENV_VAR_PREFIX = ''
+                    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
+                    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
+                }
+
+        """.trimIndent())
+    }
+
+}

--- a/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/gradle/05-validate-remote-build-caching-ci-local.sh
@@ -194,18 +194,19 @@ validate_build_config() {
 }
 
 execute_build() {
+  local args
+  args=(--build-cache --init-script "${INIT_SCRIPTS_DIR}/configure-remote-build-caching.gradle")
+  if [ -n "${remote_build_cache_url}" ]; then
+    args+=("-Ddevelocity.build-validation.remoteBuildCacheUrl=${remote_build_cache_url}")
+  fi
+
+  # shellcheck disable=SC2206  # we want tasks to expand with word splitting in this case
+  args+=(clean ${tasks})
+
   info "Running build:"
-  print_gradle_command
-
-  # shellcheck disable=SC2086  # we want tasks to expand with word splitting in this case
-  invoke_gradle 1 \
-     --build-cache \
-     --init-script "${INIT_SCRIPTS_DIR}/configure-remote-build-caching.gradle" \
-     clean ${tasks}
-}
-
-print_gradle_command() {
   info "./gradlew --build-cache -Dscan.tag.${EXP_SCAN_TAG} -Dscan.value.runId=${RUN_ID} -Dpts.enabled=false clean ${tasks}$(print_extra_args)"
+
+  invoke_gradle 1 "${args[@]}"
 }
 
 # Overrides summary.sh#print_experiment_specific_summary_info

--- a/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
@@ -1,10 +1,10 @@
 import org.gradle.util.GradleVersion
 import java.nio.charset.StandardCharsets
 
-static getInputParam(String name) {
+def getInputParam = { String name ->
     def ENV_VAR_PREFIX = ''
     def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def isTopLevelBuild = !gradle.parent
@@ -34,12 +34,16 @@ def registerBuildScanActions = { def buildScan, def rootProjectName ->
         // the configuration of the build, and given its value changes between consecutive build invocations
         // it would always invalidate the configuration cache model from the first build invocation
         // in the second build invocation
-        def getInputParam = { String name ->
-            def ENV_VAR_PREFIX = ''
-            def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
+        //
+        // System.getProperty can be used here because system properties can be read at *execution* time
+        // safely for Gradle 7.0.2 and earlier, and we must do so anyway because referencing a Gradle
+        // script object, e.g., 'gradle.startParameter', from a Groovy closure is not compatible with
+        // configuration cache
+        def getRunNumInputParam = { String name ->
+            def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
             return System.getProperty(name) ?: System.getenv(envVarName)
         }
-        def runNum = getInputParam('develocity.build-validation.runNum')
+        def runNum = getRunNumInputParam('develocity.build-validation.runNum')
         def buildScanUri = publishedBuildScan.buildScanUri
         def buildScanId = publishedBuildScan.buildScanId
         def port = (buildScanUri.port != -1) ? ':' + buildScanUri.port : ''

--- a/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-local-build-caching.gradle
@@ -1,7 +1,7 @@
-static getInputParam(String name) {
+def getInputParam = { String name ->
     def ENV_VAR_PREFIX = ''
     def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def expDir = getInputParam('develocity.build-validation.expDir')

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -1,7 +1,7 @@
-static getInputParam(String name) {
+def getInputParam = { String name ->
     def ENV_VAR_PREFIX = ''
     def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def remoteBuildCacheUrl = getInputParam('develocity.build-validation.remoteBuildCacheUrl')

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 invoke_gradle() {
-  local run_num envs
-  envs=()
+  local run_num
   run_num=$1
   shift
 

--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 invoke_gradle() {
-  local run_num
+  local run_num args
+  args=()
   run_num=$1
   shift
 
@@ -11,45 +12,35 @@ invoke_gradle() {
     cd "${project_dir}" > /dev/null 2>&1 || die "ERROR: Subdirectory ${project_dir} (set with --project-dir) does not exist in ${project_name}" "${INVALID_INPUT}"
   fi
 
-  envs+=(
-    DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=develocity-injection.gradle
-    DEVELOCITY_INJECTION_ENABLED=true
+  args+=(
+    --init-script "${INIT_SCRIPTS_DIR}/develocity-injection.gradle"
+    --init-script "${INIT_SCRIPTS_DIR}/configure-build-validation.gradle"
+    -Ddevelocity.injection.init-script-name=develocity-injection.gradle
+    -Ddevelocity.injection-enabled=true
   )
 
   if [ "$enable_ge" == "on" ]; then
-    envs+=(
-      GRADLE_PLUGIN_REPOSITORY_URL=https://plugins.gradle.org/m2
-      DEVELOCITY_PLUGIN_VERSION="3.14.1"
-      DEVELOCITY_CCUD_PLUGIN_VERSION="2.0.2"
+    args+=(
+      -Dgradle.plugin-repository.url=https://plugins.gradle.org/m2
+      -Ddevelocity.plugin.version="3.14.1"
+      -Ddevelocity.ccud.plugin.version="2.0.2"
     )
   fi
 
   if [ -n "${ge_server}" ]; then
-    envs+=(
-      DEVELOCITY_BUILD_VALIDATION_URL="${ge_server}"
-      DEVELOCITY_BUILD_VALIDATION_ALLOW_UNTRUSTED_SERVER=false
+    args+=(
+      -Ddevelocity.build-validation.url="${ge_server}"
+      -Ddevelocity.build-validation.allow-untrusted-server=false
     )
   fi
 
-  if [ -n "${remote_build_cache_url}" ]; then
-    envs+=(
-      DEVELOCITY_BUILD_VALIDATION_REMOTEBUILDCACHEURL="${remote_build_cache_url}"
-    )
-  fi
-
-  envs+=(
-    DEVELOCITY_BUILD_VALIDATION_EXPDIR="${EXP_DIR}"
-    DEVELOCITY_BUILD_VALIDATION_EXPID="${EXP_SCAN_TAG}"
-    DEVELOCITY_BUILD_VALIDATION_RUNID="${RUN_ID}"
-    DEVELOCITY_BUILD_VALIDATION_RUNNUM="${run_num}"
-    DEVELOCITY_BUILD_VALIDATION_SCRIPTSVERSION="${SCRIPT_VERSION}"
-    DEVELOCITY_CAPTURE_FILE_FINGERPRINTS=true
-  )
-
-  local args
-  args=(
-    --init-script "${INIT_SCRIPTS_DIR}/develocity-injection.gradle"
-    --init-script "${INIT_SCRIPTS_DIR}/configure-build-validation.gradle"
+  args+=(
+    -Ddevelocity.build-validation.expDir="${EXP_DIR}"
+    -Ddevelocity.build-validation.expId="${EXP_SCAN_TAG}"
+    -Ddevelocity.build-validation.runId="${RUN_ID}"
+    -Ddevelocity.build-validation.runNum="${run_num}"
+    -Ddevelocity.build-validation.scriptsVersion="${SCRIPT_VERSION}"
+    -Ddevelocity.capture-file-fingerprints=true
     -Dpts.enabled=false
   )
 
@@ -66,13 +57,9 @@ invoke_gradle() {
   rm -f "${EXP_DIR}/errors.txt"
 
   debug "Current directory: $(pwd)"
-  # shellcheck disable=SC2145
-  debug export "${envs[@]}"';' ./gradlew "${args[@]}"
+  debug ./gradlew "${args[@]}"
 
-  # The parenthesis below will intentionally create a subshell. This causes the
-  # environment variables to only be exported for the child process and not leak
-  # to the rest of the script.
-  if (export "${envs[@]}"; ./gradlew "${args[@]}"); then
+  if ./gradlew "${args[@]}"; then
       build_outcomes+=("SUCCESSFUL")
   else
       build_outcomes+=("FAILED")

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,4 +1,4 @@
 > [!IMPORTANT]
 > The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
 
-- [NEW] TBD
+[FIX] Scripts do not detect published build scans for Gradle 5.x causing experiments to fail


### PR DESCRIPTION
This PR:

1) Reverts the change for configuring init scripts via environment variables
2) (re)Migrates init scripts to use `gradle.startParameter` to read system properties

I suggest reviewing only the last 2 commits as the first 2 only revert the previous changes.

Relevant diff: https://github.com/gradle/gradle-enterprise-build-validation-scripts/pull/682/files/64f48ec26c9fb43c51d62d281a9c3a99554342e1..632519d8c0cf14190fe3ac6608b72ac50fd791d4