### PR TITLE
Remove macos-15-intel from cross-platform test matrix

### DIFF
--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -46,7 +46,6 @@ jobs:
         os:
           - ubuntu-24.04
           - macos-15
-          - macos-15-intel
           - windows-2025
         # Only LTS versions greater than 8 are tested
         java-version: [ '8', '11', '17', '21' ]
@@ -54,8 +53,6 @@ jobs:
           - os: ubuntu-24.04
             shell: bash
           - os: macos-15
-            shell: bash
-          - os: macos-15-intel
             shell: bash
           - os: windows-2025
             shell: wsl-bash


### PR DESCRIPTION
## Problem

The **Run Cross-Platform Tests (Build From Source)** workflow has been red on every push since ~late April 2026. The only failing jobs are the four **`macos-15-intel`** matrix entries (Java 8/11/17/21); ubuntu-24.04, arm64 macos-15, and windows-2025 all pass — so 12 of 16 test jobs are green but the run still reports failure.

Every failure is at **Run Gradle Experiment 01**:

```
Execution failed for task ':compileTestGroovy'.
> /Users/runner/.gradle/jdks/bellsoft-8-x86_64-os_x.2/jre/lib/libosx.dylib: dlopen(...):
    Library not loaded: @rpath/JavaNativeFoundation
    Reason: tried: '.../jre/lib/JavaNativeFoundation' (no such file), ... (no such file)
```

## Root cause

The Gradle experiments build the third-party sample [`etiennestuder/java-ordered-properties`](https://github.com/etiennestuder/java-ordered-properties), whose `build.gradle` pins the toolchain:

```groovy
toolchain {
    languageVersion = JavaLanguageVersion.of(8)
    vendor = JvmVendorSpec.BELLSOFT
}
```

Gradle therefore provisions a **BellSoft Liberica JDK 8** to compile the sample, regardless of which JDK the matrix installs. The x86_64 macOS build of that old JDK 8 ships a `libosx.dylib` linked against Apple's `JavaNativeFoundation` framework, which has been **removed from the macOS 15 runner image**. When Groovy compilation forks a worker on that JVM, `dlopen` fails and the build dies.

This is an **x86_64-macOS + old-JDK-8 + macOS-15 incompatibility**, not a defect in the validation scripts:

| Platform | Liberica 8 behavior | Result |
|---|---|---|
| `macos-15-intel` (x86_64) | Liberica 8 x86_64 downloaded → broken `libosx.dylib` | ❌ |
| `macos-15` (arm64) | No Liberica 8 for aarch64 macOS → Gradle falls back to installed Zulu 8 | ✅ |
| ubuntu / windows | Liberica 8 downloads and works | ✅ |

Because the vendor pin lives in a third-party repo and *every* x86_64 Liberica 8 build is broken on macOS 15, installing a different JDK doesn't help — Gradle still downloads Liberica to satisfy `vendor = BELLSOFT`.

## Fix

Remove `macos-15-intel` from the matrix. Cost is x86_64 macOS coverage, but the scripts under test are bash, the failure is environmental, and arm64 `macos-15` retains macOS coverage. (`macos-15-intel` replaced the old `macos-13` x86_64 runner in Dec 2025.)
