### PR TITLE
Switch `gradle.com` links to `develocity.ai`

### DIFF
--- a/Gradle.md
+++ b/Gradle.md
@@ -10,7 +10,7 @@ There are currently five experiments for Gradle. You could also perform these ex
 
 You must have the following tooling in order to use the Develocity Build Validation Scripts:
 
-- [Develocity](https://gradle.com/develocity/)
+- [Develocity](https://develocity.ai/)
 - [Bash](https://www.gnu.org/software/bash/)
 
 For users running on Windows, you will need to [install Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install).
@@ -152,9 +152,9 @@ If this does not complete successfully and produce a proper experiment summary, 
 
 ## Authenticating with Develocity
 
-Some scripts fetch data from build scans that were published as part of running an experiment. The build scan data is fetched by leveraging the [Develocity API](https://docs.gradle.com/develocity/api-manual/). It is not strictly necessary that you have permission to call these APIs to execute a script successfully, but the summary provided once the script has finished running its experiment will be more comprehensive if the build scan data is accessible.
+Some scripts fetch data from build scans that were published as part of running an experiment. The build scan data is fetched by leveraging the [Develocity API](https://docs.develocity.ai/current/reference/develocity-api/). It is not strictly necessary that you have permission to call these APIs to execute a script successfully, but the summary provided once the script has finished running its experiment will be more comprehensive if the build scan data is accessible.
 
-You can check your granted permissions by navigating in the browser to the 'My Settings' section from the user menu of your Develocity UI. You need the 'Access build data via the API' permission. Additionally, the script needs an access key to authenticate with the APIs. See [Authenticating with Develocity](https://docs.gradle.com/develocity/gradle-plugin/current/#authenticating) for details on how to create an access key and storing it locally.
+You can check your granted permissions by navigating in the browser to the 'My Settings' section from the user menu of your Develocity UI. You need the 'Access build data via the API' permission. Additionally, the script needs an access key to authenticate with the APIs. See [Authenticating with Develocity](https://docs.develocity.ai/gradle/current/gradle-plugin/#authenticating) for details on how to create an access key and storing it locally.
 
 By default, the scripts fetching build scan data try to find the access key in the `develocity/keys.properties` file within the Gradle user home directory (`~/.gradle` by default). Alternatively, the access key can be specified via the `DEVELOCITY_ACCESS_KEY` environment variable. You can also authenticate with the APIs using username and password instead by setting the `DEVELOCITY_USERNAME` and `DEVELOCITY_PASSWORD` environment variables.
 

--- a/Maven.md
+++ b/Maven.md
@@ -10,7 +10,7 @@ There are currently four experiments for Maven. You could also perform these exp
 
 You must have the following tooling in order to use the Develocity Build Validation Scripts:
 
-- [Develocity](https://gradle.com/develocity/)
+- [Develocity](https://develocity.ai/)
 - [Bash](https://www.gnu.org/software/bash/)
 
 For users running on Windows, you will need to [install Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install).
@@ -150,9 +150,9 @@ If this does not complete successfully and produce a proper experiment summary, 
 
 ## Authenticating with Develocity
 
-Some scripts fetch data from build scans that were published as part of running an experiment. The build scan data is fetched by leveraging the [Develocity API](https://docs.gradle.com/develocity/api-manual/). It is not strictly necessary that you have permission to call these APIs to execute a script successfully, but the summary provided once the script has finished running its experiment will be more comprehensive if the build scan data is accessible.
+Some scripts fetch data from build scans that were published as part of running an experiment. The build scan data is fetched by leveraging the [Develocity API](https://docs.develocity.ai/current/reference/develocity-api/). It is not strictly necessary that you have permission to call these APIs to execute a script successfully, but the summary provided once the script has finished running its experiment will be more comprehensive if the build scan data is accessible.
 
-You can check your granted permissions by navigating in the browser to the 'My Settings' section from the user menu of your Develocity UI. You need the 'Access build data via the API' permission. Additionally, the script needs an access key to authenticate with the APIs. See [Authenticating with Develocity](https://docs.gradle.com/develocity/maven-extension/current/#authenticating_with_develocity) for details on how to create an access key and storing it locally.
+You can check your granted permissions by navigating in the browser to the 'My Settings' section from the user menu of your Develocity UI. You need the 'Access build data via the API' permission. Additionally, the script needs an access key to authenticate with the APIs. See [Authenticating with Develocity](https://docs.develocity.ai/maven/current/maven-extension/#authenticating) for details on how to create an access key and storing it locally.
 
 By default, the scripts fetching build scan data try to find the access key in the `.m2/.develocity/keys.properties` file within the user's home directory. Alternatively, the access key can be specified via the `DEVELOCITY_ACCESS_KEY` environment variable. You can also authenticate with the APIs using username and password instead by setting the `DEVELOCITY_USERNAME` and `DEVELOCITY_PASSWORD` environment variables.
 

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ The Develocity build validation scripts are open-source software released under 
 [develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [quarkus-build-caching-extension]: https://github.com/gradle/quarkus-build-caching-extension
-[develocity]: https://gradle.com/develocity
+[develocity]: https://develocity.ai
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/components/licenses/NOTICE
+++ b/components/licenses/NOTICE
@@ -160,12 +160,12 @@ Build Scan Summary
 ------------------
 Copyright 2024 Gradle, Inc.
 
-Subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://gradle.com/legal/terms-of-use/ (the "Gradle License").
+Subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://develocity.ai/legal/gradle-technologies-terms-of-use/ (the "Gradle License").
 You may not use this library except in compliance with the Gradle License.
 
 Gradle Enterprise Maven Extension
 ---------------------------------
 Copyright 2024 Gradle, Inc.
 
-Subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://gradle.com/legal/terms-of-use/ (the "Gradle License").
+Subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://develocity.ai/legal/gradle-technologies-terms-of-use/ (the "Gradle License").
 You may not use this library except in compliance with the Gradle License.

--- a/components/licenses/gradle/LICENSE
+++ b/components/licenses/gradle/LICENSE
@@ -6,6 +6,6 @@ The files titled 01-validate-incremental-building.sh, 02-validate-local-build-ca
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-All files located in the folder titled "lib/develocity" are subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://gradle.com/legal/terms-of-use/ (the "Gradle License"). You may not use these files except in compliance with the Gradle License.
+All files located in the folder titled "lib/develocity" are subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://develocity.ai/legal/gradle-technologies-terms-of-use/ (the "Gradle License"). You may not use these files except in compliance with the Gradle License.
 
 This content includes certain third party libraries as set forth in the folder titled "lib/third-party". For copyright and license information for these third party libraries, please see the file titled "NOTICE".

--- a/components/licenses/maven/LICENSE
+++ b/components/licenses/maven/LICENSE
@@ -6,6 +6,6 @@ The files titled 01-validate-local-build-caching-same-location.sh, 02-validate-l
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-All files located in the folder titled "lib/develocity" are subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://gradle.com/legal/terms-of-use/ (the "Gradle License"). You may not use these files except in compliance with the Gradle License.
+All files located in the folder titled "lib/develocity" are subject to and licensed pursuant to the Gradle, Inc. Terms of Use, available at https://develocity.ai/legal/gradle-technologies-terms-of-use/ (the "Gradle License"). You may not use these files except in compliance with the Gradle License.
 
 This content includes certain third party libraries as set forth in the folder titled "lib/third-party". For copyright and license information for these third party libraries, please see the file titled "NOTICE".

--- a/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
@@ -100,9 +100,9 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         afterEvaluate {
             if (!pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID) && !pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
                 if (atLeastGradle5) {
-                    failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.gradle.com/develocity/gradle-plugin/current/#gradle_5_x')
+                    failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.develocity.ai/gradle/current/gradle-plugin/#gradle_5_x')
                 } else {
-                    failMissingPlugin(BUILD_SCAN_PLUGIN_ID, 'https://docs.gradle.com/develocity/gradle-plugin/legacy/#gradle_2_1_4_10_3')
+                    failMissingPlugin(BUILD_SCAN_PLUGIN_ID, 'https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#older-gradle')
                 }
             }
 
@@ -114,7 +114,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 // only execute if Develocity plugin isn't applied
                 if (pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) return
                 if (!buildScan.server) {
-                    failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/legacy#gradle_5_x_2')
+                    failMissingDevelocityServerURL('https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#connecting_to_develocity')
                 }
 
                 buildScan.publishAlways()
@@ -125,7 +125,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
                 if (!develocity.server.present) {
                     develocity.buildScan.publishing.onlyIf { false } // prevent publishing to scans.gradle.com
-                    failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/current/#connecting_to_develocity')
+                    failMissingDevelocityServerURL('https://docs.develocity.ai/gradle/current/gradle-plugin/#connecting_to_develocity')
                 }
 
                 develocity.buildScan.publishing.onlyIf { true }
@@ -137,7 +137,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 } else {
     gradle.settingsEvaluated { settings ->
         if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-            failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.gradle.com/develocity/gradle-plugin/current/#gradle_6_x_and_later')
+            failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.develocity.ai/gradle/4.5/gradle-plugin/#gradle_6_x_and_later')
         }
 
         if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
@@ -148,7 +148,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             // only execute if Develocity plugin isn't applied
             if (settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) return
             if (!settings.gradleEnterprise.server) {
-                failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/legacy/#gradle_6_x_and_later_2')
+                failMissingDevelocityServerURL('https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#connecting_to_develocity')
             }
 
             settings.gradleEnterprise.buildScan.publishAlways()
@@ -159,7 +159,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
             if (!settings.develocity.server.present) {
                 settings.develocity.buildScan.publishing.onlyIf { false } // prevent publishing to scans.gradle.com
-                failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/current/#connecting_to_develocity')
+                failMissingDevelocityServerURL('https://docs.develocity.ai/gradle/current/gradle-plugin/#gradle_6_x_and_later')
             }
 
             settings.develocity.buildScan.publishing.onlyIf { true }

--- a/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
@@ -137,7 +137,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 } else {
     gradle.settingsEvaluated { settings ->
         if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-            failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.develocity.ai/gradle/4.5/gradle-plugin/#gradle_6_x_and_later')
+            failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.develocity.ai/gradle/current/gradle-plugin/#gradle_6_x_and_later')
         }
 
         if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
@@ -159,7 +159,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
             if (!settings.develocity.server.present) {
                 settings.develocity.buildScan.publishing.onlyIf { false } // prevent publishing to scans.gradle.com
-                failMissingDevelocityServerURL('https://docs.develocity.ai/gradle/current/gradle-plugin/#gradle_6_x_and_later')
+                failMissingDevelocityServerURL('https://docs.develocity.ai/gradle/current/gradle-plugin/#connecting_to_develocity')
             }
 
             settings.develocity.buildScan.publishing.onlyIf { true }

--- a/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
@@ -100,9 +100,9 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         afterEvaluate {
             if (!pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID) && !pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
                 if (atLeastGradle5) {
-                    failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.develocity.ai/gradle/current/gradle-plugin/#gradle_5_x')
+                    failMissingPlugin(DEVELOCITY_PLUGIN_ID, 'https://docs.develocity.ai/gradle/current/gradle-plugin/#gradle-5-x')
                 } else {
-                    failMissingPlugin(BUILD_SCAN_PLUGIN_ID, 'https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#older-gradle')
+                    failMissingPlugin(BUILD_SCAN_PLUGIN_ID, 'https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#gradle_2_1_4_10_3')
                 }
             }
 
@@ -114,7 +114,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 // only execute if Develocity plugin isn't applied
                 if (pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) return
                 if (!buildScan.server) {
-                    failMissingDevelocityServerURL('https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#connecting_to_develocity')
+                    failMissingDevelocityServerURL('https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#gradle_5_x_2')
                 }
 
                 buildScan.publishAlways()
@@ -148,7 +148,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             // only execute if Develocity plugin isn't applied
             if (settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) return
             if (!settings.gradleEnterprise.server) {
-                failMissingDevelocityServerURL('https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#connecting_to_develocity')
+                failMissingDevelocityServerURL('https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#gradle_6_x_and_later_2')
             }
 
             settings.gradleEnterprise.buildScan.publishAlways()

--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -10,8 +10,6 @@ def expDir = getInputParam(gradle, 'develocity.build-validation.expDir')
 def remoteBuildCacheType = getInputParam(gradle, 'develocity.build-validation.remoteBuildCacheType')
 def remoteBuildCacheUrl = getInputParam(gradle, 'develocity.build-validation.remoteBuildCacheUrl')
 
-def docsRoot = 'https://docs.gradle.com/develocity/gradle-plugin'
-
 settingsEvaluated { Settings settings ->
     settings.buildCache {
         local {
@@ -28,7 +26,7 @@ settingsEvaluated { Settings settings ->
                 logger.debug("Configuring remote build cache implementation for '${settings.rootProject.name}' as: ${remoteBuildCacheImplementation}")
                 remote(remoteBuildCacheImplementation)
             } else if (isTopLevelBuild) {
-                failMissingRequiredImplementation(remoteBuildCacheType, expDir, docsRoot)
+                failMissingRequiredImplementation(remoteBuildCacheType, expDir)
             }
         }
 
@@ -43,7 +41,7 @@ settingsEvaluated { Settings settings ->
                 if (remoteBuildCacheUrl) {
                     remote.url = remoteBuildCacheUri
                 } else if (!remote.url) {
-                    failMissingUrlForHttpBuildCache(expDir, docsRoot)
+                    failMissingUrlForHttpBuildCache(expDir)
                 }
             } else if (isBuildCacheImplementationFor(remote, 'com.gradle.develocity') || isBuildCacheImplementationFor(remote, 'com.gradle.enterprise')) {
                 if (remoteBuildCacheUri) {
@@ -52,7 +50,7 @@ settingsEvaluated { Settings settings ->
                 }
             }
         } else if (isTopLevelBuild) {
-            failMissingRemoteBuildCacheConfiguration(expDir, docsRoot)
+            failMissingRemoteBuildCacheConfiguration(expDir)
         }
     }
 }
@@ -93,36 +91,36 @@ static void failInvalidRemoteBuildCacheType(String remoteBuildCacheType, String 
     throw new IllegalStateException(message)
 }
 
-static void failMissingRequiredImplementation(String remoteBuildCacheType, String expDir, String docsRoot) {
+static void failMissingRequiredImplementation(String remoteBuildCacheType, String expDir) {
     def errorFile = new File(expDir, 'errors.txt')
     errorFile.text = "Remote build cache connector type '${remoteBuildCacheType}' requested, but the required plugin is not applied."
     if (remoteBuildCacheType == 'develocity') {
         throw new IllegalStateException("Remote build cache connector type 'develocity' requested,\n" +
             "but the Develocity Gradle plugin is not applied.\n" +
-            "Either apply it directly (see $docsRoot/current/#applying_the_plugin),\n" +
+            "Either apply it directly (see https://docs.develocity.ai/gradle/current/gradle-plugin/#applying_the_plugin),\n" +
             "use --enable-develocity to enable the plugin,\n" +
             "or use --remote-build-cache-type to choose a different remote build cache connector type\n" +
             "when running the build validation script.")
     } else {
         throw new IllegalStateException("Remote build cache connector type 'gradle-enterprise' requested,\n" +
-            "but the Gradle Enterprise Gradle plugin is not applied (see $docsRoot/legacy/#applying_the_plugin).")
+            "but the Gradle Enterprise Gradle plugin is not applied (see https://docs.gradle.com/develocity/legacy/gradle-plugin/legacy/#applying_the_plugin).")
     }
 }
 
 // Gradle already fails in this case, but handling it here means we can fail the experiment more
 // gracefully and provide guidance the user.
-static void failMissingUrlForHttpBuildCache(String expDir, String docsRoot) {
+static void failMissingUrlForHttpBuildCache(String expDir) {
     def errorFile = new File(expDir, 'errors.txt')
     errorFile.text = 'A remote build cache URL has not been configured in the project or on the command line.'
     throw new IllegalStateException("A remote build cache URL is not configured.\n"
-        + "Either configure it directly (see $docsRoot/current/#using_gradles_built_in_http_connector) in the project,\n"
+        + "Either configure it directly (see https://docs.develocity.ai/gradle/current/gradle-plugin/#using-gradles-built-in-http-connector) in the project,\n"
         + "or use --remote-build-cache-url when running the build validation script.")
 }
 
-static void failMissingRemoteBuildCacheConfiguration(String expDir, String docsRoot) {
+static void failMissingRemoteBuildCacheConfiguration(String expDir) {
     def errorFile = new File(expDir, 'errors.txt')
     errorFile.text = "Remote build cache is not configured for the project."
     throw new IllegalStateException("Remote build cache is not configured for the project.\n" +
-        "Either configure it directly (see $docsRoot/current/#using_the_develocity_connector),\n" +
+        "Either configure it directly (see https://docs.develocity.ai/gradle/current/gradle-plugin/#using_the_develocity_connector),\n" +
         "or use --remote-build-cache-type when running the build validation script.")
 }

--- a/components/scripts/lib/interactive-mode.sh
+++ b/components/scripts/lib/interactive-mode.sh
@@ -178,7 +178,7 @@ If you choose option b) and do not want to interfere with an already existing
 build caching configuration in your build, you can override the local and
 remote build cache configuration via system properties right when triggering
 the build on CI. Details on how to provide the overrides are available from the
-documentation of the the Develocity Maven extension.
+documentation of the Develocity Maven extension.
 
 https://docs.develocity.ai/maven/current/maven-extension/#configuring_the_remote_cache
 EOF

--- a/components/scripts/lib/interactive-mode.sh
+++ b/components/scripts/lib/interactive-mode.sh
@@ -45,7 +45,7 @@ during daily development, it is advisable that you apply the Common Custom User
 Data Gradle plugin to your build. Details on how to apply the plugin are
 available from the documentation of the build validation scripts.
 
-https://gradle.com/bvs/main/Gradle.md#applying-the-common-custom-user-data-gradle-plugin
+https://develocity.ai/bvs/main/Gradle.md#applying-the-common-custom-user-data-gradle-plugin
 
 Your updated build configuration should be pushed before proceeding.
 
@@ -73,7 +73,7 @@ during daily development, it is advisable that you apply the Common Custom User
 Data Maven extension to your build. Details on how to apply the extension are
 available from the documentation of the build validation scripts.
 
-https://gradle.com/bvs/main/Maven.md#applying-the-common-custom-user-data-maven-extension
+https://develocity.ai/bvs/main/Maven.md#applying-the-common-custom-user-data-maven-extension
 
 Your updated build configuration should be pushed before proceeding.
 
@@ -180,7 +180,7 @@ remote build cache configuration via system properties right when triggering
 the build on CI. Details on how to provide the overrides are available from the
 documentation of the the Develocity Maven extension.
 
-https://docs.gradle.com/develocity/maven-extension/current/#configuring_the_remote_cache
+https://docs.develocity.ai/maven/current/maven-extension/#configuring_the_remote_cache
 EOF
   else
     IFS='' read -r -d '' build_tool_instructions <<EOF
@@ -239,9 +239,9 @@ explain_prerequisites_api_access() {
   fi
 
   if [[ "${BUILD_TOOL}" == "Maven" ]]; then
-    documentation_link="https://gradle.com/bvs/main/Maven.md#authenticating-with-develocity"
+    documentation_link="https://develocity.ai/bvs/main/Maven.md#authenticating-with-develocity"
   else
-    documentation_link="https://gradle.com/bvs/main/Gradle.md#authenticating-with-develocity"
+    documentation_link="https://develocity.ai/bvs/main/Gradle.md#authenticating-with-develocity"
   fi
 
   IFS='' read -r -d '' text <<EOF

--- a/components/scripts/lib/summary.sh
+++ b/components/scripts/lib/summary.sh
@@ -311,9 +311,9 @@ print_performance_characteristics_footer() {
 
 performance_characteristics_link() {
   if [[ "${BUILD_TOOL}" == "Maven" ]]; then
-    echo "https://gradle.com/bvs/main/Maven.md#performance-characteristics"
+    echo "https://develocity.ai/bvs/main/Maven.md#performance-characteristics"
   else
-    echo "https://gradle.com/bvs/main/Gradle.md#performance-characteristics"
+    echo "https://develocity.ai/bvs/main/Gradle.md#performance-characteristics"
   fi
 }
 

--- a/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
+++ b/components/scripts/maven/04-validate-remote-build-caching-ci-local.sh
@@ -331,7 +331,7 @@ navigating in the browser to the 'My Settings' section from the user menu of
 your Develocity UI. Your Develocity access key must be specified in the
 ~/.m2/.develocity/keys.properties file.
 
-https://docs.gradle.com/develocity/maven-extension/current/#via_file
+https://docs.develocity.ai/maven/current/maven-extension/#via-file
 
 Some of the fetched build scan data is expected to be present as custom values.
 By default, this experiment assumes that these custom values have been created


### PR DESCRIPTION
This pull request updates documentation and script references throughout the project to use the new Develocity domain (`develocity.ai`) instead of the old Gradle domain (`gradle.com`). It also updates links to point to the correct, current documentation paths. These changes ensure that users are directed to the most up-to-date resources and that error messages provide accurate guidance.