### PR TITLE
Inject the legacy distribution deprecation banner into the release notes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -411,6 +411,10 @@ fun releaseVersion(): Provider<String> {
 }
 
 fun releaseNotes(): Provider<String> {
+    val legacyDeprecationBanner = """
+        > [!IMPORTANT]
+        > The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
+    """.trimIndent()
     val releaseNotesFile = layout.projectDirectory.file("release/changes.md")
-    return providers.fileContents(releaseNotesFile).asText.map { it.trim() }
+    return providers.fileContents(releaseNotesFile).asText.map { "$legacyDeprecationBanner\n\n${it.trim()}" }
 }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,4 +1,1 @@
-> [!IMPORTANT]
-> The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
-
 - [NEW] TBD


### PR DESCRIPTION
This prepends the banner to the GitHub release body during the build, so `release/changes.md` contains only changelog entries and can be reset to '- [NEW] TBD' after each release without accidentally dropping the banner. Every release body still leads with the deprecation notice until the legacy distributions are removed.